### PR TITLE
Honor color property for background

### DIFF
--- a/avatar.jsx
+++ b/avatar.jsx
@@ -251,7 +251,7 @@ module.exports = (function() {
       };
 
       var initialsStyle = {
-        background: this.rndColor(),
+        background: this.props.color || this.rndColor(),
         width: this.props.size,
         height: this.props.size,
         font: Math.floor(this.props.size/3) + 'px/100px Helvetica, Arial, sans-serif',


### PR DESCRIPTION
In my code I also calculate a hash of the name and use that as the index of the rnd color, so the same username gets the same color always. I can submit that patch also, but minimally, it should honor the color property as described in the docs.