### PR TITLE
Remove deprecated MD5, replace with md5@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reactify": "^1.0.0"
   },
   "dependencies": {
-    "MD5": "^1.2.1",
+    "md5": "^2.0.0",
     "grunt-react": "^0.10.0",
     "is-array": "^1.0.1",
     "react": "^0.14.0",


### PR DESCRIPTION
stops deprecation warnings from legacy MD5—replaced with successor md5@2.0.0

see: https://github.com/pvorb/node-md5/commit/c018e8932d0fbb2a200a540a055da487f4f9c150

