### PR TITLE
[Facebook] use width and height for graph request

### DIFF
--- a/src/sources/Facebook.js
+++ b/src/sources/Facebook.js
@@ -13,7 +13,8 @@ class FacebookSource {
 
     get = (setState) => {
         const { size, facebookId } = this.props;
-        const url = `https://graph.facebook.com/${facebookId}/picture?width=${size}`;
+        const url = 'https://graph.facebook.com/' +
+            `${facebookId}/picture?width=${size}&height=${size}`;
 
         setState({src: url});
     }


### PR DESCRIPTION
Use both the width and height parameters when requesting the Facebook avatar from Graph API, this way Facebook returns the portrait/landscape image like the user has specified it should look when squared.

Only width:
![screenshot 2016-06-27 16 34 28](https://cloud.githubusercontent.com/assets/1267900/16383482/86bcfa04-3c85-11e6-8225-baf555844658.png)

Width + height:
![screenshot 2016-06-27 16 32 10](https://cloud.githubusercontent.com/assets/1267900/16383489/90598dfc-3c85-11e6-9080-2e3a5deec421.png)
