### PR TITLE
[build] add babel-runtime transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
    "presets": ["es2015", "react", "stage-0"],
-   "plugins": ["add-module-exports"]
+   "plugins": [
+       "transform-runtime",
+       "add-module-exports"
+   ]
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-regenerator-runtime": "^6.5.0",
     "babel-register": "^6.5.2",
-    "babel-runtime": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.1",
     "browserify-global-shim": "^1.0.3",
@@ -62,6 +61,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
+    "babel-runtime": ">=5.0.0",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0",
     "react": "^0.14.0",


### PR DESCRIPTION
The `transform-runtime` plugin was installed but not being used. This results in not all ES2015 code being transpiled, leaving things like `Array.from` in the built library.

I also moved the actual `babel-runtime` dependency to dependencies because the built version requires code from that package. As a result, consuming packages need to install it too. (https://babeljs.io/docs/plugins/transform-runtime/)