### PR TITLE
`react-*` should be peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Install the component using [NPM](https://www.npmjs.com/):
 
 ```sh
 $ npm install react-avatar --save
+
+# besides React, react-avatar also has react-addons-shallow-compare
+# as a peer dependency, make sure to install the correct version
+# for your version of react
+$ npm install react-addons-shallow-compare@^0.14 --save
+# OR
+$ npm install react-addons-shallow-compare@^15 --save
 ```
 
 Or [download as ZIP](https://github.com/sitebase/react-avatar/archive/master.zip).

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "homepage": "https://github.com/sitebase/react-avatar",
   "peerDependencies": {
-    "react": ">=0.14"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "browserify-global-shim": {},
   "devDependencies": {
@@ -57,15 +58,15 @@
     "browserify-global-shim": "^1.0.3",
     "eslint": "1.10.3",
     "eslint-plugin-react": "3.5.1",
-    "react-dom": ">=0.14.0",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
+    "react-addons-shallow-compare": "^15.0.0",
     "reactify": "^1.0.0",
     "watchify": "^3.7.0"
   },
   "dependencies": {
     "babel-runtime": ">=5.0.0",
     "is-retina": "^1.0.3",
-    "md5": "^2.0.0",
-    "react": ">=0.14.0",
-    "react-addons-shallow-compare": ">=0.14.0"
+    "md5": "^2.0.0"
   }
 }


### PR DESCRIPTION
All react dependencies should be peerDependencies to avoid conflicting react versions in your build. It's a bit of a PITA that consumers have to manually install the `react-addon-shallow-compare` but if you don't do this, you get bugs like I describe below.

### Current scenario

1. You have a project that uses React@0.14, but doesn't use `react-addon-shallow-compare`
2. `npm install --save react-avatar`
3. npm install `react-avatar` and the latest version of `react-addon-shallow-compare`, which is `>15`
4. The latest version of `react-addon-shallow-compare` needs React@15 and you end up getting __UNMET PEER DEPENDENCY__ errors.

Users now have two ways of solving that error:

1. Install react@15, which results in two react versions in your build
2. Install `react-addon-shallow-compare@0.14`, which is the right thing to do.

### Scenario after merging this PR

1. You have a project that uses any version of react, but doesn't use `react-addon-shallow-compare`
2. `npm install --save react-avatar`
3. You get a __UNMET PEER DEPENDENCY__ error telling you you have to install `react-addon-shallow-compare`
4. You solve this by installing the correct version of the plugin in your project

I've also added this to the README because it might not be obvious. I think this is the way to go if you want to support multiple react versions though.