### PR TITLE
Migrate to prop-types module.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactAddonsShallowCompare = require('react-addons-shallow-compare');
 
 var _reactAddonsShallowCompare2 = _interopRequireDefault(_reactAddonsShallowCompare);
@@ -262,24 +266,24 @@ var Avatar = function (_React$Component) {
 
 Avatar.displayName = 'Avatar';
 Avatar.propTypes = {
-    className: _react2.default.PropTypes.string,
-    fgColor: _react2.default.PropTypes.string,
-    color: _react2.default.PropTypes.string,
-    colors: _react2.default.PropTypes.array,
-    name: _react2.default.PropTypes.string,
-    value: _react2.default.PropTypes.string,
-    email: _react2.default.PropTypes.string,
-    md5Email: _react2.default.PropTypes.string,
-    src: _react2.default.PropTypes.string,
-    facebookId: _react2.default.PropTypes.string,
-    googleId: _react2.default.PropTypes.string,
-    twitterHandle: _react2.default.PropTypes.string,
-    vkontakteId: _react2.default.PropTypes.string,
-    skypeId: _react2.default.PropTypes.string,
-    round: _react2.default.PropTypes.bool,
-    style: _react2.default.PropTypes.object,
-    size: _react2.default.PropTypes.number,
-    textSizeRatio: _react2.default.PropTypes.number
+    className: _propTypes2.default.string,
+    fgColor: _propTypes2.default.string,
+    color: _propTypes2.default.string,
+    colors: _propTypes2.default.array,
+    name: _propTypes2.default.string,
+    value: _propTypes2.default.string,
+    email: _propTypes2.default.string,
+    md5Email: _propTypes2.default.string,
+    src: _propTypes2.default.string,
+    facebookId: _propTypes2.default.string,
+    googleId: _propTypes2.default.string,
+    twitterHandle: _propTypes2.default.string,
+    vkontakteId: _propTypes2.default.string,
+    skypeId: _propTypes2.default.string,
+    round: _propTypes2.default.bool,
+    style: _propTypes2.default.object,
+    size: _propTypes2.default.number,
+    textSizeRatio: _propTypes2.default.number
 };
 Avatar.defaultProps = {
     className: 'sb-avatar',

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-runtime": ">=5.0.0",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0",
+    "prop-types": "^15.5.8",
     "react": ">=0.14.0",
     "react-addons-shallow-compare": ">=0.14.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import {cacheFailingSource, hasSourceFailedBefore} from './utils.js';
 
@@ -29,24 +30,24 @@ const SOURCES = [
 export default class Avatar extends React.Component {
     static displayName = 'Avatar'
     static propTypes = {
-        className: React.PropTypes.string,
-        fgColor: React.PropTypes.string,
-        color: React.PropTypes.string,
-        colors: React.PropTypes.array,
-        name: React.PropTypes.string,
-        value: React.PropTypes.string,
-        email: React.PropTypes.string,
-        md5Email: React.PropTypes.string,
-        src: React.PropTypes.string,
-        facebookId: React.PropTypes.string,
-        googleId: React.PropTypes.string,
-        twitterHandle: React.PropTypes.string,
-        vkontakteId: React.PropTypes.string,
-        skypeId: React.PropTypes.string,
-        round: React.PropTypes.bool,
-        style: React.PropTypes.object,
-        size: React.PropTypes.number,
-        textSizeRatio: React.PropTypes.number
+        className: PropTypes.string,
+        fgColor: PropTypes.string,
+        color: PropTypes.string,
+        colors: PropTypes.array,
+        name: PropTypes.string,
+        value: PropTypes.string,
+        email: PropTypes.string,
+        md5Email: PropTypes.string,
+        src: PropTypes.string,
+        facebookId: PropTypes.string,
+        googleId: PropTypes.string,
+        twitterHandle: PropTypes.string,
+        vkontakteId: PropTypes.string,
+        skypeId: PropTypes.string,
+        round: PropTypes.bool,
+        style: PropTypes.object,
+        size: PropTypes.number,
+        textSizeRatio: PropTypes.number
     }
 
     static defaultProps = {


### PR DESCRIPTION
From React v15.5.0: Accessing PropTypes via the main React package is deprecated.
React.PropTypes is replaced with PropTypes from 'prop-types' module. 
This fixes #59 