### PR TITLE
Replacing legacy shallow-compare with PureComponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
   ],
   "homepage": "https://github.com/sitebase/react-avatar",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "prop-types": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0",
+    "prop-types": "^15.0.0 || ^16.0.0"
   },
   "browserify-global-shim": {},
   "devDependencies": {
@@ -61,7 +60,6 @@
     "eslint-plugin-react": "3.5.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-addons-shallow-compare": "^15.0.0",
     "reactify": "^1.0.0",
     "watchify": "^3.7.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import {cacheFailingSource, hasSourceFailedBefore} from './utils.js';
 
 import gravatarSource from './sources/Gravatar.js';
@@ -27,7 +26,7 @@ const SOURCES = [
     iconSource
 ];
 
-export default class Avatar extends React.Component {
+export default class Avatar extends PureComponent {
     static displayName = 'Avatar'
     static propTypes = {
         className: PropTypes.string,
@@ -125,10 +124,6 @@ export default class Avatar extends React.Component {
             nextState._internal.sourcePointer = 0;
             this.setState(nextState, this.fetch);
         }
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-        return shallowCompare(this, nextProps, nextState);
     }
 
     tryNextsource = (Source, next) => {


### PR DESCRIPTION
Fixes #66 
This change is not retro compatible, So you cant use it with  react < 0.15.3.
But React-addons-shallow-compare is a legacy react code.
Anyways if some wants to keep using 0.14.x react version can use older version of this plugin.