### PR TITLE
Remove engines field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.5.1",
   "description": "Universal React avatar component makes it possible to generate avatars based on user information.",
   "main": "lib/index.js",
-  "engines": {
-    "node": "8.x.x"
-  },
   "scripts": {
     "clean": "rm -rf ./lib/*",
     "transpile": "babel ./src --out-dir ./lib",


### PR DESCRIPTION
The engines field is causing yarn to stumble. I'm running node 9 and I can't install react-avatar without the `--ignore-engines` flag. Considering the plugin is already compiled to es5 do you mind if we just remove it?

```
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error react-avatar@2.5.1: The engine "node" is incompatible with this module. Expected version "8.x.x".
error Found incompatible module
```