### PR TITLE
Fix for handling error resulting from bad image src url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ export default class Avatar extends PureComponent {
         if( event && event.type === 'error' ) {
             cacheFailingSource(this.state.src);
             this.setState({src: null});
-	    return;
+            return;
         }
 
         // console.log('## fetch');

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ export default class Avatar extends PureComponent {
         if( event && event.type === 'error' ) {
             cacheFailingSource(this.state.src);
             this.setState({src: null});
+	    return;
         }
 
         // console.log('## fetch');


### PR DESCRIPTION
Return after call to setState src to null.  This will cause the state to be updated and then a fresh render to be evaluated after the new state has been set.  Otherwise the next source will be called and attempted, overwriting the state so that the image source is never null'd out and acted upon.