### PR TITLE
[size] allow unit types in value

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Some examples:
 | `value`       | *string*          |         | Show a value as avatar                                                                                 |
 | `color`       | *string*          | random  | Used in combination with `name` and `value`. Give the background a fixed color with a hex like for example #FF0000 |
 | `fgColor`     | *string*          | #FFF  | Used in combination with `name` and `value`. Give the text a fixed color with a hex like for example #FF0000 |
-| `size`        | *number*             | 50      | Size of the avatar                                                                                     |
+| `size`        | *[length][1]*             | 50px      | Size of the avatar                                                                                     |
 | `textSizeRatio` | *number*             | 3      | For text based avatars the size of the text as a fragment of size (size / textSizeRatio)                                 |
 | `round`       | *bool*            | false   | Round the avatar corners                                                                               |
 | `src`         | *string*          |         | Fallback image to use                                                                                  |
@@ -131,3 +131,5 @@ For detailed changelog, check [Releases](https://github.com/sitebase/react-avata
 ## License
 
 [MIT License](http://opensource.org/licenses/MIT)
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/length

--- a/build/demo.js
+++ b/build/demo.js
@@ -230,6 +230,31 @@ var Demo = function (_React$Component) {
           _react2.default.createElement(
             'h2',
             null,
+            'Sizes in different units'
+          ),
+          _react2.default.createElement(
+            'div',
+            null,
+            _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '30pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '90pt', round: true, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '170pt', textSizeRatio: 4 })
+          ),
+          _react2.default.createElement(
+            'div',
+            null,
+            _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '4vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '6vw', round: true, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '15vw', textSizeRatio: 4 })
+          )
+        ),
+        _react2.default.createElement(
+          'section',
+          null,
+          _react2.default.createElement(
+            'h2',
+            null,
             'Initials with maximum number of characters'
           ),
           _react2.default.createElement(
@@ -315,7 +340,7 @@ exports.default = Demo;
 var mountNode = document.getElementById('container');
 _reactDom2.default.render(_react2.default.createElement(Demo, null), mountNode);
 module.exports = exports['default'];
-},{"./index.js":2,"babel-runtime/core-js/object/get-prototype-of":17,"babel-runtime/helpers/classCallCheck":22,"babel-runtime/helpers/createClass":23,"babel-runtime/helpers/inherits":25,"babel-runtime/helpers/possibleConstructorReturn":26,"react":305,"react-dom":153}],2:[function(require,module,exports){
+},{"./index.js":2,"babel-runtime/core-js/object/get-prototype-of":19,"babel-runtime/helpers/classCallCheck":24,"babel-runtime/helpers/createClass":25,"babel-runtime/helpers/inherits":27,"babel-runtime/helpers/possibleConstructorReturn":28,"react":312,"react-dom":160}],2:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -515,17 +540,17 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsImage',
         value: function _renderAsImage() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var round = this.props.round;
             var alt = this.props.name || this.props.value;
             var imageStyle = this.props.unstyled ? null : {
                 maxWidth: '100%',
-                width: size,
-                height: size,
+                width: size.str,
+                height: size.str,
                 borderRadius: round ? 500 : 0
             };
-            return _react2.default.createElement('img', { width: this.props.size,
-                height: this.props.size,
+            return _react2.default.createElement('img', { width: size.str,
+                height: size.str,
                 style: imageStyle,
                 src: this.state.src,
                 alt: alt,
@@ -534,14 +559,14 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsText',
         value: function _renderAsText() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var textSizeRatio = this.props.textSizeRatio;
             var round = this.props.round;
             var initialsStyle = this.props.unstyled ? null : {
-                width: size,
-                height: size,
-                font: Math.floor(size / textSizeRatio) + 'px Helvetica, Arial, sans-serif',
-                lineHeight: size + 'px', // yes, px suffix is needed on lineHeight
+                width: size.str,
+                height: size.str,
+                font: (size.value / textSizeRatio).toFixed(4) + size.unit + ' Helvetica, Arial, sans-serif',
+                lineHeight: size.str, // yes, px suffix is needed on lineHeight
                 textAlign: 'center',
                 textTransform: 'uppercase',
                 color: this.props.fgColor,
@@ -557,11 +582,11 @@ var Avatar = function (_PureComponent) {
     }, {
         key: 'render',
         value: function render() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var hostStyle = this.props.unstyled ? null : (0, _extends3.default)({
                 display: 'inline-block',
-                width: size,
-                height: size,
+                width: size.str,
+                height: size.str,
                 borderRadius: this.props.round ? 500 : 0
             }, this.props.style);
             return _react2.default.createElement(
@@ -621,7 +646,7 @@ Avatar.defaultProps = {
 };
 exports.default = Avatar;
 module.exports = exports['default'];
-},{"./sources/Facebook.js":3,"./sources/Google.js":4,"./sources/Gravatar.js":5,"./sources/Icon.js":6,"./sources/Skype.js":7,"./sources/Src.js":8,"./sources/Twitter.js":9,"./sources/Value.js":10,"./sources/Vkontakte.js":11,"./utils.js":12,"babel-runtime/core-js/object/get-prototype-of":17,"babel-runtime/core-js/object/keys":18,"babel-runtime/helpers/classCallCheck":22,"babel-runtime/helpers/createClass":23,"babel-runtime/helpers/extends":24,"babel-runtime/helpers/inherits":25,"babel-runtime/helpers/possibleConstructorReturn":26,"prop-types":151,"react":305}],3:[function(require,module,exports){
+},{"./sources/Facebook.js":3,"./sources/Google.js":4,"./sources/Gravatar.js":5,"./sources/Icon.js":6,"./sources/Skype.js":7,"./sources/Src.js":8,"./sources/Twitter.js":9,"./sources/Value.js":10,"./sources/Vkontakte.js":11,"./utils.js":12,"babel-runtime/core-js/object/get-prototype-of":19,"babel-runtime/core-js/object/keys":20,"babel-runtime/helpers/classCallCheck":24,"babel-runtime/helpers/createClass":25,"babel-runtime/helpers/extends":26,"babel-runtime/helpers/inherits":27,"babel-runtime/helpers/possibleConstructorReturn":28,"prop-types":158,"react":312}],3:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -659,7 +684,7 @@ var FacebookSource = function FacebookSource(props) {
 
 exports.default = FacebookSource;
 module.exports = exports['default'];
-},{"babel-runtime/helpers/classCallCheck":22}],4:[function(require,module,exports){
+},{"babel-runtime/helpers/classCallCheck":24}],4:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -714,7 +739,7 @@ var GoogleSource = function GoogleSource(props) {
 
 exports.default = GoogleSource;
 module.exports = exports['default'];
-},{"../utils":12,"babel-runtime/helpers/classCallCheck":22}],5:[function(require,module,exports){
+},{"../utils":12,"babel-runtime/helpers/classCallCheck":24}],5:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -767,7 +792,7 @@ var _initialiseProps = function _initialiseProps() {
 
 exports.default = GravatarSource;
 module.exports = exports['default'];
-},{"babel-runtime/helpers/classCallCheck":22,"is-retina":143,"md5":144}],6:[function(require,module,exports){
+},{"babel-runtime/helpers/classCallCheck":24,"is-retina":150,"md5":151}],6:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -805,7 +830,7 @@ var IconSource = function IconSource(props) {
 
 exports.default = IconSource;
 module.exports = exports['default'];
-},{"../utils":12,"babel-runtime/helpers/classCallCheck":22}],7:[function(require,module,exports){
+},{"../utils":12,"babel-runtime/helpers/classCallCheck":24}],7:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -841,7 +866,7 @@ var SkypeSource = function SkypeSource(props) {
 
 exports.default = SkypeSource;
 module.exports = exports['default'];
-},{"babel-runtime/helpers/classCallCheck":22}],8:[function(require,module,exports){
+},{"babel-runtime/helpers/classCallCheck":24}],8:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -875,7 +900,7 @@ var SrcSource = function SrcSource(props) {
 
 exports.default = SrcSource;
 module.exports = exports['default'];
-},{"babel-runtime/helpers/classCallCheck":22}],9:[function(require,module,exports){
+},{"babel-runtime/helpers/classCallCheck":24}],9:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -936,7 +961,7 @@ var TwitterSource = function () {
 
 exports.default = TwitterSource;
 module.exports = exports['default'];
-},{"babel-runtime/helpers/classCallCheck":22,"babel-runtime/helpers/createClass":23}],10:[function(require,module,exports){
+},{"babel-runtime/helpers/classCallCheck":24,"babel-runtime/helpers/createClass":25}],10:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1014,7 +1039,7 @@ var ValueSource = function () {
 
 exports.default = ValueSource;
 module.exports = exports['default'];
-},{"../utils":12,"babel-runtime/helpers/classCallCheck":22,"babel-runtime/helpers/createClass":23}],11:[function(require,module,exports){
+},{"../utils":12,"babel-runtime/helpers/classCallCheck":24,"babel-runtime/helpers/createClass":25}],11:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
@@ -1084,12 +1109,16 @@ var GoogleSource = function () {
 
 exports.default = GoogleSource;
 module.exports = exports['default'];
-},{"../utils":12,"babel-runtime/helpers/classCallCheck":22,"babel-runtime/helpers/createClass":23}],12:[function(require,module,exports){
+},{"../utils":12,"babel-runtime/helpers/classCallCheck":24,"babel-runtime/helpers/createClass":25}],12:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
+
+var _slicedToArray2 = require('babel-runtime/helpers/slicedToArray');
+
+var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
 
 var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
@@ -1098,6 +1127,7 @@ var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
 exports.fetch = fetch;
 exports.fetchJSONP = fetchJSONP;
 exports.getRandomColor = getRandomColor;
+exports.parseSize = parseSize;
 exports.cacheFailingSource = cacheFailingSource;
 exports.hasSourceFailedBefore = hasSourceFailedBefore;
 
@@ -1139,6 +1169,9 @@ function fetchJSONP(url, successCb, errorCb) {
 
 var defaultColors = ['#d73d32', '#7e3794', '#4285f4', '#67ae3f', '#d61a7f', '#ff4080'];
 
+// https://regex101.com/r/YEsPER/1
+var reSize = /^([-+]?(?:\d+(?:\.\d+)?|\.\d+))([a-z]{2,4})?$/;
+
 function _stringAsciiCodeSum(value) {
     return [].concat((0, _toConsumableArray3.default)(value)).map(function (letter) {
         return letter.charCodeAt(0);
@@ -1163,6 +1196,23 @@ function getRandomColor(value) {
     var sum = _stringAsciiCodeSum(value);
     var colorIndex = sum % colors.length;
     return colors[colorIndex];
+}
+
+function parseSize(size) {
+    size = '' + size;
+
+    var _ref = reSize.exec(size) || [],
+        _ref2 = (0, _slicedToArray3.default)(_ref, 3),
+        _ref2$ = _ref2[1],
+        value = _ref2$ === undefined ? 0 : _ref2$,
+        _ref2$2 = _ref2[2],
+        unit = _ref2$2 === undefined ? 'px' : _ref2$2;
+
+    return {
+        value: parseFloat(value),
+        str: value + unit,
+        unit: unit
+    };
 }
 
 function isLocalStorageAvailable() {
@@ -1204,25 +1254,29 @@ function hasSourceFailedBefore(source) {
     var cache = localStorage.getItem(CACHE_KEY) || '';
     return cache.indexOf(source) > -1;
 }
-},{"babel-runtime/helpers/toConsumableArray":27}],13:[function(require,module,exports){
+},{"babel-runtime/helpers/slicedToArray":29,"babel-runtime/helpers/toConsumableArray":30}],13:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/array/from"), __esModule: true };
-},{"core-js/library/fn/array/from":30}],14:[function(require,module,exports){
+},{"core-js/library/fn/array/from":33}],14:[function(require,module,exports){
+module.exports = { "default": require("core-js/library/fn/get-iterator"), __esModule: true };
+},{"core-js/library/fn/get-iterator":34}],15:[function(require,module,exports){
+module.exports = { "default": require("core-js/library/fn/is-iterable"), __esModule: true };
+},{"core-js/library/fn/is-iterable":35}],16:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/assign"), __esModule: true };
-},{"core-js/library/fn/object/assign":31}],15:[function(require,module,exports){
+},{"core-js/library/fn/object/assign":36}],17:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/create"), __esModule: true };
-},{"core-js/library/fn/object/create":32}],16:[function(require,module,exports){
+},{"core-js/library/fn/object/create":37}],18:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/define-property"), __esModule: true };
-},{"core-js/library/fn/object/define-property":33}],17:[function(require,module,exports){
+},{"core-js/library/fn/object/define-property":38}],19:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/get-prototype-of"), __esModule: true };
-},{"core-js/library/fn/object/get-prototype-of":34}],18:[function(require,module,exports){
+},{"core-js/library/fn/object/get-prototype-of":39}],20:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/keys"), __esModule: true };
-},{"core-js/library/fn/object/keys":35}],19:[function(require,module,exports){
+},{"core-js/library/fn/object/keys":40}],21:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/object/set-prototype-of"), __esModule: true };
-},{"core-js/library/fn/object/set-prototype-of":36}],20:[function(require,module,exports){
+},{"core-js/library/fn/object/set-prototype-of":41}],22:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/symbol"), __esModule: true };
-},{"core-js/library/fn/symbol":37}],21:[function(require,module,exports){
+},{"core-js/library/fn/symbol":42}],23:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/symbol/iterator"), __esModule: true };
-},{"core-js/library/fn/symbol/iterator":38}],22:[function(require,module,exports){
+},{"core-js/library/fn/symbol/iterator":43}],24:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1232,7 +1286,7 @@ exports.default = function (instance, Constructor) {
     throw new TypeError("Cannot call a class as a function");
   }
 };
-},{}],23:[function(require,module,exports){
+},{}],25:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1260,7 +1314,7 @@ exports.default = function () {
     return Constructor;
   };
 }();
-},{"../core-js/object/define-property":16}],24:[function(require,module,exports){
+},{"../core-js/object/define-property":18}],26:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1284,7 +1338,7 @@ exports.default = _assign2.default || function (target) {
 
   return target;
 };
-},{"../core-js/object/assign":14}],25:[function(require,module,exports){
+},{"../core-js/object/assign":16}],27:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1318,7 +1372,7 @@ exports.default = function (subClass, superClass) {
   });
   if (superClass) _setPrototypeOf2.default ? (0, _setPrototypeOf2.default)(subClass, superClass) : subClass.__proto__ = superClass;
 };
-},{"../core-js/object/create":15,"../core-js/object/set-prototype-of":19,"../helpers/typeof":28}],26:[function(require,module,exports){
+},{"../core-js/object/create":17,"../core-js/object/set-prototype-of":21,"../helpers/typeof":31}],28:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1336,7 +1390,59 @@ exports.default = function (self, call) {
 
   return call && ((typeof call === "undefined" ? "undefined" : (0, _typeof3.default)(call)) === "object" || typeof call === "function") ? call : self;
 };
-},{"../helpers/typeof":28}],27:[function(require,module,exports){
+},{"../helpers/typeof":31}],29:[function(require,module,exports){
+"use strict";
+
+exports.__esModule = true;
+
+var _isIterable2 = require("../core-js/is-iterable");
+
+var _isIterable3 = _interopRequireDefault(_isIterable2);
+
+var _getIterator2 = require("../core-js/get-iterator");
+
+var _getIterator3 = _interopRequireDefault(_getIterator2);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function () {
+  function sliceIterator(arr, i) {
+    var _arr = [];
+    var _n = true;
+    var _d = false;
+    var _e = undefined;
+
+    try {
+      for (var _i = (0, _getIterator3.default)(arr), _s; !(_n = (_s = _i.next()).done); _n = true) {
+        _arr.push(_s.value);
+
+        if (i && _arr.length === i) break;
+      }
+    } catch (err) {
+      _d = true;
+      _e = err;
+    } finally {
+      try {
+        if (!_n && _i["return"]) _i["return"]();
+      } finally {
+        if (_d) throw _e;
+      }
+    }
+
+    return _arr;
+  }
+
+  return function (arr, i) {
+    if (Array.isArray(arr)) {
+      return arr;
+    } else if ((0, _isIterable3.default)(Object(arr))) {
+      return sliceIterator(arr, i);
+    } else {
+      throw new TypeError("Invalid attempt to destructure non-iterable instance");
+    }
+  };
+}();
+},{"../core-js/get-iterator":14,"../core-js/is-iterable":15}],30:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1358,7 +1464,7 @@ exports.default = function (arr) {
     return (0, _from2.default)(arr);
   }
 };
-},{"../core-js/array/from":13}],28:[function(require,module,exports){
+},{"../core-js/array/from":13}],31:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -1380,7 +1486,7 @@ exports.default = typeof _symbol2.default === "function" && _typeof(_iterator2.d
 } : function (obj) {
   return obj && typeof _symbol2.default === "function" && obj.constructor === _symbol2.default && obj !== _symbol2.default.prototype ? "symbol" : typeof obj === "undefined" ? "undefined" : _typeof(obj);
 };
-},{"../core-js/symbol":20,"../core-js/symbol/iterator":21}],29:[function(require,module,exports){
+},{"../core-js/symbol":22,"../core-js/symbol/iterator":23}],32:[function(require,module,exports){
 var charenc = {
   // UTF-8 encoding
   utf8: {
@@ -1415,70 +1521,80 @@ var charenc = {
 
 module.exports = charenc;
 
-},{}],30:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
 require('../../modules/es6.string.iterator');
 require('../../modules/es6.array.from');
 module.exports = require('../../modules/_core').Array.from;
 
-},{"../../modules/_core":45,"../../modules/es6.array.from":103,"../../modules/es6.string.iterator":112}],31:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.array.from":110,"../../modules/es6.string.iterator":119}],34:[function(require,module,exports){
+require('../modules/web.dom.iterable');
+require('../modules/es6.string.iterator');
+module.exports = require('../modules/core.get-iterator');
+
+},{"../modules/core.get-iterator":108,"../modules/es6.string.iterator":119,"../modules/web.dom.iterable":123}],35:[function(require,module,exports){
+require('../modules/web.dom.iterable');
+require('../modules/es6.string.iterator');
+module.exports = require('../modules/core.is-iterable');
+
+},{"../modules/core.is-iterable":109,"../modules/es6.string.iterator":119,"../modules/web.dom.iterable":123}],36:[function(require,module,exports){
 require('../../modules/es6.object.assign');
 module.exports = require('../../modules/_core').Object.assign;
 
-},{"../../modules/_core":45,"../../modules/es6.object.assign":105}],32:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.assign":112}],37:[function(require,module,exports){
 require('../../modules/es6.object.create');
 var $Object = require('../../modules/_core').Object;
 module.exports = function create(P, D) {
   return $Object.create(P, D);
 };
 
-},{"../../modules/_core":45,"../../modules/es6.object.create":106}],33:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.create":113}],38:[function(require,module,exports){
 require('../../modules/es6.object.define-property');
 var $Object = require('../../modules/_core').Object;
 module.exports = function defineProperty(it, key, desc) {
   return $Object.defineProperty(it, key, desc);
 };
 
-},{"../../modules/_core":45,"../../modules/es6.object.define-property":107}],34:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.define-property":114}],39:[function(require,module,exports){
 require('../../modules/es6.object.get-prototype-of');
 module.exports = require('../../modules/_core').Object.getPrototypeOf;
 
-},{"../../modules/_core":45,"../../modules/es6.object.get-prototype-of":108}],35:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.get-prototype-of":115}],40:[function(require,module,exports){
 require('../../modules/es6.object.keys');
 module.exports = require('../../modules/_core').Object.keys;
 
-},{"../../modules/_core":45,"../../modules/es6.object.keys":109}],36:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.keys":116}],41:[function(require,module,exports){
 require('../../modules/es6.object.set-prototype-of');
 module.exports = require('../../modules/_core').Object.setPrototypeOf;
 
-},{"../../modules/_core":45,"../../modules/es6.object.set-prototype-of":110}],37:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.set-prototype-of":117}],42:[function(require,module,exports){
 require('../../modules/es6.symbol');
 require('../../modules/es6.object.to-string');
 require('../../modules/es7.symbol.async-iterator');
 require('../../modules/es7.symbol.observable');
 module.exports = require('../../modules/_core').Symbol;
 
-},{"../../modules/_core":45,"../../modules/es6.object.to-string":111,"../../modules/es6.symbol":113,"../../modules/es7.symbol.async-iterator":114,"../../modules/es7.symbol.observable":115}],38:[function(require,module,exports){
+},{"../../modules/_core":50,"../../modules/es6.object.to-string":118,"../../modules/es6.symbol":120,"../../modules/es7.symbol.async-iterator":121,"../../modules/es7.symbol.observable":122}],43:[function(require,module,exports){
 require('../../modules/es6.string.iterator');
 require('../../modules/web.dom.iterable');
 module.exports = require('../../modules/_wks-ext').f('iterator');
 
-},{"../../modules/_wks-ext":100,"../../modules/es6.string.iterator":112,"../../modules/web.dom.iterable":116}],39:[function(require,module,exports){
+},{"../../modules/_wks-ext":105,"../../modules/es6.string.iterator":119,"../../modules/web.dom.iterable":123}],44:[function(require,module,exports){
 module.exports = function (it) {
   if (typeof it != 'function') throw TypeError(it + ' is not a function!');
   return it;
 };
 
-},{}],40:[function(require,module,exports){
+},{}],45:[function(require,module,exports){
 module.exports = function () { /* empty */ };
 
-},{}],41:[function(require,module,exports){
+},{}],46:[function(require,module,exports){
 var isObject = require('./_is-object');
 module.exports = function (it) {
   if (!isObject(it)) throw TypeError(it + ' is not an object!');
   return it;
 };
 
-},{"./_is-object":63}],42:[function(require,module,exports){
+},{"./_is-object":68}],47:[function(require,module,exports){
 // false -> Array#indexOf
 // true  -> Array#includes
 var toIObject = require('./_to-iobject');
@@ -1503,7 +1619,7 @@ module.exports = function (IS_INCLUDES) {
   };
 };
 
-},{"./_to-absolute-index":92,"./_to-iobject":94,"./_to-length":95}],43:[function(require,module,exports){
+},{"./_to-absolute-index":97,"./_to-iobject":99,"./_to-length":100}],48:[function(require,module,exports){
 // getting tag from 19.1.3.6 Object.prototype.toString()
 var cof = require('./_cof');
 var TAG = require('./_wks')('toStringTag');
@@ -1528,18 +1644,18 @@ module.exports = function (it) {
     : (B = cof(O)) == 'Object' && typeof O.callee == 'function' ? 'Arguments' : B;
 };
 
-},{"./_cof":44,"./_wks":101}],44:[function(require,module,exports){
+},{"./_cof":49,"./_wks":106}],49:[function(require,module,exports){
 var toString = {}.toString;
 
 module.exports = function (it) {
   return toString.call(it).slice(8, -1);
 };
 
-},{}],45:[function(require,module,exports){
+},{}],50:[function(require,module,exports){
 var core = module.exports = { version: '2.5.1' };
 if (typeof __e == 'number') __e = core; // eslint-disable-line no-undef
 
-},{}],46:[function(require,module,exports){
+},{}],51:[function(require,module,exports){
 'use strict';
 var $defineProperty = require('./_object-dp');
 var createDesc = require('./_property-desc');
@@ -1549,7 +1665,7 @@ module.exports = function (object, index, value) {
   else object[index] = value;
 };
 
-},{"./_object-dp":74,"./_property-desc":85}],47:[function(require,module,exports){
+},{"./_object-dp":79,"./_property-desc":90}],52:[function(require,module,exports){
 // optional / simple context binding
 var aFunction = require('./_a-function');
 module.exports = function (fn, that, length) {
@@ -1571,20 +1687,20 @@ module.exports = function (fn, that, length) {
   };
 };
 
-},{"./_a-function":39}],48:[function(require,module,exports){
+},{"./_a-function":44}],53:[function(require,module,exports){
 // 7.2.1 RequireObjectCoercible(argument)
 module.exports = function (it) {
   if (it == undefined) throw TypeError("Can't call method on  " + it);
   return it;
 };
 
-},{}],49:[function(require,module,exports){
+},{}],54:[function(require,module,exports){
 // Thank's IE8 for his funny defineProperty
 module.exports = !require('./_fails')(function () {
   return Object.defineProperty({}, 'a', { get: function () { return 7; } }).a != 7;
 });
 
-},{"./_fails":54}],50:[function(require,module,exports){
+},{"./_fails":59}],55:[function(require,module,exports){
 var isObject = require('./_is-object');
 var document = require('./_global').document;
 // typeof document.createElement is 'object' in old IE
@@ -1593,13 +1709,13 @@ module.exports = function (it) {
   return is ? document.createElement(it) : {};
 };
 
-},{"./_global":55,"./_is-object":63}],51:[function(require,module,exports){
+},{"./_global":60,"./_is-object":68}],56:[function(require,module,exports){
 // IE 8- don't enum bug keys
 module.exports = (
   'constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf'
 ).split(',');
 
-},{}],52:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 // all enumerable object keys, includes symbols
 var getKeys = require('./_object-keys');
 var gOPS = require('./_object-gops');
@@ -1616,7 +1732,7 @@ module.exports = function (it) {
   } return result;
 };
 
-},{"./_object-gops":79,"./_object-keys":82,"./_object-pie":83}],53:[function(require,module,exports){
+},{"./_object-gops":84,"./_object-keys":87,"./_object-pie":88}],58:[function(require,module,exports){
 var global = require('./_global');
 var core = require('./_core');
 var ctx = require('./_ctx');
@@ -1679,7 +1795,7 @@ $export.U = 64;  // safe
 $export.R = 128; // real proto method for `library`
 module.exports = $export;
 
-},{"./_core":45,"./_ctx":47,"./_global":55,"./_hide":57}],54:[function(require,module,exports){
+},{"./_core":50,"./_ctx":52,"./_global":60,"./_hide":62}],59:[function(require,module,exports){
 module.exports = function (exec) {
   try {
     return !!exec();
@@ -1688,7 +1804,7 @@ module.exports = function (exec) {
   }
 };
 
-},{}],55:[function(require,module,exports){
+},{}],60:[function(require,module,exports){
 // https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
 var global = module.exports = typeof window != 'undefined' && window.Math == Math
   ? window : typeof self != 'undefined' && self.Math == Math ? self
@@ -1696,13 +1812,13 @@ var global = module.exports = typeof window != 'undefined' && window.Math == Mat
   : Function('return this')();
 if (typeof __g == 'number') __g = global; // eslint-disable-line no-undef
 
-},{}],56:[function(require,module,exports){
+},{}],61:[function(require,module,exports){
 var hasOwnProperty = {}.hasOwnProperty;
 module.exports = function (it, key) {
   return hasOwnProperty.call(it, key);
 };
 
-},{}],57:[function(require,module,exports){
+},{}],62:[function(require,module,exports){
 var dP = require('./_object-dp');
 var createDesc = require('./_property-desc');
 module.exports = require('./_descriptors') ? function (object, key, value) {
@@ -1712,16 +1828,16 @@ module.exports = require('./_descriptors') ? function (object, key, value) {
   return object;
 };
 
-},{"./_descriptors":49,"./_object-dp":74,"./_property-desc":85}],58:[function(require,module,exports){
+},{"./_descriptors":54,"./_object-dp":79,"./_property-desc":90}],63:[function(require,module,exports){
 var document = require('./_global').document;
 module.exports = document && document.documentElement;
 
-},{"./_global":55}],59:[function(require,module,exports){
+},{"./_global":60}],64:[function(require,module,exports){
 module.exports = !require('./_descriptors') && !require('./_fails')(function () {
   return Object.defineProperty(require('./_dom-create')('div'), 'a', { get: function () { return 7; } }).a != 7;
 });
 
-},{"./_descriptors":49,"./_dom-create":50,"./_fails":54}],60:[function(require,module,exports){
+},{"./_descriptors":54,"./_dom-create":55,"./_fails":59}],65:[function(require,module,exports){
 // fallback for non-array-like ES3 and non-enumerable old V8 strings
 var cof = require('./_cof');
 // eslint-disable-next-line no-prototype-builtins
@@ -1729,7 +1845,7 @@ module.exports = Object('z').propertyIsEnumerable(0) ? Object : function (it) {
   return cof(it) == 'String' ? it.split('') : Object(it);
 };
 
-},{"./_cof":44}],61:[function(require,module,exports){
+},{"./_cof":49}],66:[function(require,module,exports){
 // check on default Array iterator
 var Iterators = require('./_iterators');
 var ITERATOR = require('./_wks')('iterator');
@@ -1739,19 +1855,19 @@ module.exports = function (it) {
   return it !== undefined && (Iterators.Array === it || ArrayProto[ITERATOR] === it);
 };
 
-},{"./_iterators":69,"./_wks":101}],62:[function(require,module,exports){
+},{"./_iterators":74,"./_wks":106}],67:[function(require,module,exports){
 // 7.2.2 IsArray(argument)
 var cof = require('./_cof');
 module.exports = Array.isArray || function isArray(arg) {
   return cof(arg) == 'Array';
 };
 
-},{"./_cof":44}],63:[function(require,module,exports){
+},{"./_cof":49}],68:[function(require,module,exports){
 module.exports = function (it) {
   return typeof it === 'object' ? it !== null : typeof it === 'function';
 };
 
-},{}],64:[function(require,module,exports){
+},{}],69:[function(require,module,exports){
 // call something on iterator step with safe closing on error
 var anObject = require('./_an-object');
 module.exports = function (iterator, fn, value, entries) {
@@ -1765,7 +1881,7 @@ module.exports = function (iterator, fn, value, entries) {
   }
 };
 
-},{"./_an-object":41}],65:[function(require,module,exports){
+},{"./_an-object":46}],70:[function(require,module,exports){
 'use strict';
 var create = require('./_object-create');
 var descriptor = require('./_property-desc');
@@ -1780,7 +1896,7 @@ module.exports = function (Constructor, NAME, next) {
   setToStringTag(Constructor, NAME + ' Iterator');
 };
 
-},{"./_hide":57,"./_object-create":73,"./_property-desc":85,"./_set-to-string-tag":88,"./_wks":101}],66:[function(require,module,exports){
+},{"./_hide":62,"./_object-create":78,"./_property-desc":90,"./_set-to-string-tag":93,"./_wks":106}],71:[function(require,module,exports){
 'use strict';
 var LIBRARY = require('./_library');
 var $export = require('./_export');
@@ -1852,7 +1968,7 @@ module.exports = function (Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCE
   return methods;
 };
 
-},{"./_export":53,"./_has":56,"./_hide":57,"./_iter-create":65,"./_iterators":69,"./_library":70,"./_object-gpo":80,"./_redefine":86,"./_set-to-string-tag":88,"./_wks":101}],67:[function(require,module,exports){
+},{"./_export":58,"./_has":61,"./_hide":62,"./_iter-create":70,"./_iterators":74,"./_library":75,"./_object-gpo":85,"./_redefine":91,"./_set-to-string-tag":93,"./_wks":106}],72:[function(require,module,exports){
 var ITERATOR = require('./_wks')('iterator');
 var SAFE_CLOSING = false;
 
@@ -1876,18 +1992,18 @@ module.exports = function (exec, skipClosing) {
   return safe;
 };
 
-},{"./_wks":101}],68:[function(require,module,exports){
+},{"./_wks":106}],73:[function(require,module,exports){
 module.exports = function (done, value) {
   return { value: value, done: !!done };
 };
 
-},{}],69:[function(require,module,exports){
+},{}],74:[function(require,module,exports){
 module.exports = {};
 
-},{}],70:[function(require,module,exports){
+},{}],75:[function(require,module,exports){
 module.exports = true;
 
-},{}],71:[function(require,module,exports){
+},{}],76:[function(require,module,exports){
 var META = require('./_uid')('meta');
 var isObject = require('./_is-object');
 var has = require('./_has');
@@ -1942,7 +2058,7 @@ var meta = module.exports = {
   onFreeze: onFreeze
 };
 
-},{"./_fails":54,"./_has":56,"./_is-object":63,"./_object-dp":74,"./_uid":98}],72:[function(require,module,exports){
+},{"./_fails":59,"./_has":61,"./_is-object":68,"./_object-dp":79,"./_uid":103}],77:[function(require,module,exports){
 'use strict';
 // 19.1.2.1 Object.assign(target, source, ...)
 var getKeys = require('./_object-keys');
@@ -1978,7 +2094,7 @@ module.exports = !$assign || require('./_fails')(function () {
   } return T;
 } : $assign;
 
-},{"./_fails":54,"./_iobject":60,"./_object-gops":79,"./_object-keys":82,"./_object-pie":83,"./_to-object":96}],73:[function(require,module,exports){
+},{"./_fails":59,"./_iobject":65,"./_object-gops":84,"./_object-keys":87,"./_object-pie":88,"./_to-object":101}],78:[function(require,module,exports){
 // 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 var anObject = require('./_an-object');
 var dPs = require('./_object-dps');
@@ -2021,7 +2137,7 @@ module.exports = Object.create || function create(O, Properties) {
   return Properties === undefined ? result : dPs(result, Properties);
 };
 
-},{"./_an-object":41,"./_dom-create":50,"./_enum-bug-keys":51,"./_html":58,"./_object-dps":75,"./_shared-key":89}],74:[function(require,module,exports){
+},{"./_an-object":46,"./_dom-create":55,"./_enum-bug-keys":56,"./_html":63,"./_object-dps":80,"./_shared-key":94}],79:[function(require,module,exports){
 var anObject = require('./_an-object');
 var IE8_DOM_DEFINE = require('./_ie8-dom-define');
 var toPrimitive = require('./_to-primitive');
@@ -2039,7 +2155,7 @@ exports.f = require('./_descriptors') ? Object.defineProperty : function defineP
   return O;
 };
 
-},{"./_an-object":41,"./_descriptors":49,"./_ie8-dom-define":59,"./_to-primitive":97}],75:[function(require,module,exports){
+},{"./_an-object":46,"./_descriptors":54,"./_ie8-dom-define":64,"./_to-primitive":102}],80:[function(require,module,exports){
 var dP = require('./_object-dp');
 var anObject = require('./_an-object');
 var getKeys = require('./_object-keys');
@@ -2054,7 +2170,7 @@ module.exports = require('./_descriptors') ? Object.defineProperties : function 
   return O;
 };
 
-},{"./_an-object":41,"./_descriptors":49,"./_object-dp":74,"./_object-keys":82}],76:[function(require,module,exports){
+},{"./_an-object":46,"./_descriptors":54,"./_object-dp":79,"./_object-keys":87}],81:[function(require,module,exports){
 var pIE = require('./_object-pie');
 var createDesc = require('./_property-desc');
 var toIObject = require('./_to-iobject');
@@ -2072,7 +2188,7 @@ exports.f = require('./_descriptors') ? gOPD : function getOwnPropertyDescriptor
   if (has(O, P)) return createDesc(!pIE.f.call(O, P), O[P]);
 };
 
-},{"./_descriptors":49,"./_has":56,"./_ie8-dom-define":59,"./_object-pie":83,"./_property-desc":85,"./_to-iobject":94,"./_to-primitive":97}],77:[function(require,module,exports){
+},{"./_descriptors":54,"./_has":61,"./_ie8-dom-define":64,"./_object-pie":88,"./_property-desc":90,"./_to-iobject":99,"./_to-primitive":102}],82:[function(require,module,exports){
 // fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
 var toIObject = require('./_to-iobject');
 var gOPN = require('./_object-gopn').f;
@@ -2093,7 +2209,7 @@ module.exports.f = function getOwnPropertyNames(it) {
   return windowNames && toString.call(it) == '[object Window]' ? getWindowNames(it) : gOPN(toIObject(it));
 };
 
-},{"./_object-gopn":78,"./_to-iobject":94}],78:[function(require,module,exports){
+},{"./_object-gopn":83,"./_to-iobject":99}],83:[function(require,module,exports){
 // 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
 var $keys = require('./_object-keys-internal');
 var hiddenKeys = require('./_enum-bug-keys').concat('length', 'prototype');
@@ -2102,10 +2218,10 @@ exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
   return $keys(O, hiddenKeys);
 };
 
-},{"./_enum-bug-keys":51,"./_object-keys-internal":81}],79:[function(require,module,exports){
+},{"./_enum-bug-keys":56,"./_object-keys-internal":86}],84:[function(require,module,exports){
 exports.f = Object.getOwnPropertySymbols;
 
-},{}],80:[function(require,module,exports){
+},{}],85:[function(require,module,exports){
 // 19.1.2.9 / 15.2.3.2 Object.getPrototypeOf(O)
 var has = require('./_has');
 var toObject = require('./_to-object');
@@ -2120,7 +2236,7 @@ module.exports = Object.getPrototypeOf || function (O) {
   } return O instanceof Object ? ObjectProto : null;
 };
 
-},{"./_has":56,"./_shared-key":89,"./_to-object":96}],81:[function(require,module,exports){
+},{"./_has":61,"./_shared-key":94,"./_to-object":101}],86:[function(require,module,exports){
 var has = require('./_has');
 var toIObject = require('./_to-iobject');
 var arrayIndexOf = require('./_array-includes')(false);
@@ -2139,7 +2255,7 @@ module.exports = function (object, names) {
   return result;
 };
 
-},{"./_array-includes":42,"./_has":56,"./_shared-key":89,"./_to-iobject":94}],82:[function(require,module,exports){
+},{"./_array-includes":47,"./_has":61,"./_shared-key":94,"./_to-iobject":99}],87:[function(require,module,exports){
 // 19.1.2.14 / 15.2.3.14 Object.keys(O)
 var $keys = require('./_object-keys-internal');
 var enumBugKeys = require('./_enum-bug-keys');
@@ -2148,10 +2264,10 @@ module.exports = Object.keys || function keys(O) {
   return $keys(O, enumBugKeys);
 };
 
-},{"./_enum-bug-keys":51,"./_object-keys-internal":81}],83:[function(require,module,exports){
+},{"./_enum-bug-keys":56,"./_object-keys-internal":86}],88:[function(require,module,exports){
 exports.f = {}.propertyIsEnumerable;
 
-},{}],84:[function(require,module,exports){
+},{}],89:[function(require,module,exports){
 // most Object methods by ES6 should accept primitives
 var $export = require('./_export');
 var core = require('./_core');
@@ -2163,7 +2279,7 @@ module.exports = function (KEY, exec) {
   $export($export.S + $export.F * fails(function () { fn(1); }), 'Object', exp);
 };
 
-},{"./_core":45,"./_export":53,"./_fails":54}],85:[function(require,module,exports){
+},{"./_core":50,"./_export":58,"./_fails":59}],90:[function(require,module,exports){
 module.exports = function (bitmap, value) {
   return {
     enumerable: !(bitmap & 1),
@@ -2173,10 +2289,10 @@ module.exports = function (bitmap, value) {
   };
 };
 
-},{}],86:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 module.exports = require('./_hide');
 
-},{"./_hide":57}],87:[function(require,module,exports){
+},{"./_hide":62}],92:[function(require,module,exports){
 // Works with __proto__ only. Old v8 can't work with null proto objects.
 /* eslint-disable no-proto */
 var isObject = require('./_is-object');
@@ -2203,7 +2319,7 @@ module.exports = {
   check: check
 };
 
-},{"./_an-object":41,"./_ctx":47,"./_is-object":63,"./_object-gopd":76}],88:[function(require,module,exports){
+},{"./_an-object":46,"./_ctx":52,"./_is-object":68,"./_object-gopd":81}],93:[function(require,module,exports){
 var def = require('./_object-dp').f;
 var has = require('./_has');
 var TAG = require('./_wks')('toStringTag');
@@ -2212,14 +2328,14 @@ module.exports = function (it, tag, stat) {
   if (it && !has(it = stat ? it : it.prototype, TAG)) def(it, TAG, { configurable: true, value: tag });
 };
 
-},{"./_has":56,"./_object-dp":74,"./_wks":101}],89:[function(require,module,exports){
+},{"./_has":61,"./_object-dp":79,"./_wks":106}],94:[function(require,module,exports){
 var shared = require('./_shared')('keys');
 var uid = require('./_uid');
 module.exports = function (key) {
   return shared[key] || (shared[key] = uid(key));
 };
 
-},{"./_shared":90,"./_uid":98}],90:[function(require,module,exports){
+},{"./_shared":95,"./_uid":103}],95:[function(require,module,exports){
 var global = require('./_global');
 var SHARED = '__core-js_shared__';
 var store = global[SHARED] || (global[SHARED] = {});
@@ -2227,7 +2343,7 @@ module.exports = function (key) {
   return store[key] || (store[key] = {});
 };
 
-},{"./_global":55}],91:[function(require,module,exports){
+},{"./_global":60}],96:[function(require,module,exports){
 var toInteger = require('./_to-integer');
 var defined = require('./_defined');
 // true  -> String#at
@@ -2246,7 +2362,7 @@ module.exports = function (TO_STRING) {
   };
 };
 
-},{"./_defined":48,"./_to-integer":93}],92:[function(require,module,exports){
+},{"./_defined":53,"./_to-integer":98}],97:[function(require,module,exports){
 var toInteger = require('./_to-integer');
 var max = Math.max;
 var min = Math.min;
@@ -2255,7 +2371,7 @@ module.exports = function (index, length) {
   return index < 0 ? max(index + length, 0) : min(index, length);
 };
 
-},{"./_to-integer":93}],93:[function(require,module,exports){
+},{"./_to-integer":98}],98:[function(require,module,exports){
 // 7.1.4 ToInteger
 var ceil = Math.ceil;
 var floor = Math.floor;
@@ -2263,7 +2379,7 @@ module.exports = function (it) {
   return isNaN(it = +it) ? 0 : (it > 0 ? floor : ceil)(it);
 };
 
-},{}],94:[function(require,module,exports){
+},{}],99:[function(require,module,exports){
 // to indexed object, toObject with fallback for non-array-like ES3 strings
 var IObject = require('./_iobject');
 var defined = require('./_defined');
@@ -2271,7 +2387,7 @@ module.exports = function (it) {
   return IObject(defined(it));
 };
 
-},{"./_defined":48,"./_iobject":60}],95:[function(require,module,exports){
+},{"./_defined":53,"./_iobject":65}],100:[function(require,module,exports){
 // 7.1.15 ToLength
 var toInteger = require('./_to-integer');
 var min = Math.min;
@@ -2279,14 +2395,14 @@ module.exports = function (it) {
   return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
 };
 
-},{"./_to-integer":93}],96:[function(require,module,exports){
+},{"./_to-integer":98}],101:[function(require,module,exports){
 // 7.1.13 ToObject(argument)
 var defined = require('./_defined');
 module.exports = function (it) {
   return Object(defined(it));
 };
 
-},{"./_defined":48}],97:[function(require,module,exports){
+},{"./_defined":53}],102:[function(require,module,exports){
 // 7.1.1 ToPrimitive(input [, PreferredType])
 var isObject = require('./_is-object');
 // instead of the ES6 spec version, we didn't implement @@toPrimitive case
@@ -2300,14 +2416,14 @@ module.exports = function (it, S) {
   throw TypeError("Can't convert object to primitive value");
 };
 
-},{"./_is-object":63}],98:[function(require,module,exports){
+},{"./_is-object":68}],103:[function(require,module,exports){
 var id = 0;
 var px = Math.random();
 module.exports = function (key) {
   return 'Symbol('.concat(key === undefined ? '' : key, ')_', (++id + px).toString(36));
 };
 
-},{}],99:[function(require,module,exports){
+},{}],104:[function(require,module,exports){
 var global = require('./_global');
 var core = require('./_core');
 var LIBRARY = require('./_library');
@@ -2318,10 +2434,10 @@ module.exports = function (name) {
   if (name.charAt(0) != '_' && !(name in $Symbol)) defineProperty($Symbol, name, { value: wksExt.f(name) });
 };
 
-},{"./_core":45,"./_global":55,"./_library":70,"./_object-dp":74,"./_wks-ext":100}],100:[function(require,module,exports){
+},{"./_core":50,"./_global":60,"./_library":75,"./_object-dp":79,"./_wks-ext":105}],105:[function(require,module,exports){
 exports.f = require('./_wks');
 
-},{"./_wks":101}],101:[function(require,module,exports){
+},{"./_wks":106}],106:[function(require,module,exports){
 var store = require('./_shared')('wks');
 var uid = require('./_uid');
 var Symbol = require('./_global').Symbol;
@@ -2334,7 +2450,7 @@ var $exports = module.exports = function (name) {
 
 $exports.store = store;
 
-},{"./_global":55,"./_shared":90,"./_uid":98}],102:[function(require,module,exports){
+},{"./_global":60,"./_shared":95,"./_uid":103}],107:[function(require,module,exports){
 var classof = require('./_classof');
 var ITERATOR = require('./_wks')('iterator');
 var Iterators = require('./_iterators');
@@ -2344,7 +2460,28 @@ module.exports = require('./_core').getIteratorMethod = function (it) {
     || Iterators[classof(it)];
 };
 
-},{"./_classof":43,"./_core":45,"./_iterators":69,"./_wks":101}],103:[function(require,module,exports){
+},{"./_classof":48,"./_core":50,"./_iterators":74,"./_wks":106}],108:[function(require,module,exports){
+var anObject = require('./_an-object');
+var get = require('./core.get-iterator-method');
+module.exports = require('./_core').getIterator = function (it) {
+  var iterFn = get(it);
+  if (typeof iterFn != 'function') throw TypeError(it + ' is not iterable!');
+  return anObject(iterFn.call(it));
+};
+
+},{"./_an-object":46,"./_core":50,"./core.get-iterator-method":107}],109:[function(require,module,exports){
+var classof = require('./_classof');
+var ITERATOR = require('./_wks')('iterator');
+var Iterators = require('./_iterators');
+module.exports = require('./_core').isIterable = function (it) {
+  var O = Object(it);
+  return O[ITERATOR] !== undefined
+    || '@@iterator' in O
+    // eslint-disable-next-line no-prototype-builtins
+    || Iterators.hasOwnProperty(classof(O));
+};
+
+},{"./_classof":48,"./_core":50,"./_iterators":74,"./_wks":106}],110:[function(require,module,exports){
 'use strict';
 var ctx = require('./_ctx');
 var $export = require('./_export');
@@ -2383,7 +2520,7 @@ $export($export.S + $export.F * !require('./_iter-detect')(function (iter) { Arr
   }
 });
 
-},{"./_create-property":46,"./_ctx":47,"./_export":53,"./_is-array-iter":61,"./_iter-call":64,"./_iter-detect":67,"./_to-length":95,"./_to-object":96,"./core.get-iterator-method":102}],104:[function(require,module,exports){
+},{"./_create-property":51,"./_ctx":52,"./_export":58,"./_is-array-iter":66,"./_iter-call":69,"./_iter-detect":72,"./_to-length":100,"./_to-object":101,"./core.get-iterator-method":107}],111:[function(require,module,exports){
 'use strict';
 var addToUnscopables = require('./_add-to-unscopables');
 var step = require('./_iter-step');
@@ -2419,23 +2556,23 @@ addToUnscopables('keys');
 addToUnscopables('values');
 addToUnscopables('entries');
 
-},{"./_add-to-unscopables":40,"./_iter-define":66,"./_iter-step":68,"./_iterators":69,"./_to-iobject":94}],105:[function(require,module,exports){
+},{"./_add-to-unscopables":45,"./_iter-define":71,"./_iter-step":73,"./_iterators":74,"./_to-iobject":99}],112:[function(require,module,exports){
 // 19.1.3.1 Object.assign(target, source)
 var $export = require('./_export');
 
 $export($export.S + $export.F, 'Object', { assign: require('./_object-assign') });
 
-},{"./_export":53,"./_object-assign":72}],106:[function(require,module,exports){
+},{"./_export":58,"./_object-assign":77}],113:[function(require,module,exports){
 var $export = require('./_export');
 // 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 $export($export.S, 'Object', { create: require('./_object-create') });
 
-},{"./_export":53,"./_object-create":73}],107:[function(require,module,exports){
+},{"./_export":58,"./_object-create":78}],114:[function(require,module,exports){
 var $export = require('./_export');
 // 19.1.2.4 / 15.2.3.6 Object.defineProperty(O, P, Attributes)
 $export($export.S + $export.F * !require('./_descriptors'), 'Object', { defineProperty: require('./_object-dp').f });
 
-},{"./_descriptors":49,"./_export":53,"./_object-dp":74}],108:[function(require,module,exports){
+},{"./_descriptors":54,"./_export":58,"./_object-dp":79}],115:[function(require,module,exports){
 // 19.1.2.9 Object.getPrototypeOf(O)
 var toObject = require('./_to-object');
 var $getPrototypeOf = require('./_object-gpo');
@@ -2446,7 +2583,7 @@ require('./_object-sap')('getPrototypeOf', function () {
   };
 });
 
-},{"./_object-gpo":80,"./_object-sap":84,"./_to-object":96}],109:[function(require,module,exports){
+},{"./_object-gpo":85,"./_object-sap":89,"./_to-object":101}],116:[function(require,module,exports){
 // 19.1.2.14 Object.keys(O)
 var toObject = require('./_to-object');
 var $keys = require('./_object-keys');
@@ -2457,14 +2594,14 @@ require('./_object-sap')('keys', function () {
   };
 });
 
-},{"./_object-keys":82,"./_object-sap":84,"./_to-object":96}],110:[function(require,module,exports){
+},{"./_object-keys":87,"./_object-sap":89,"./_to-object":101}],117:[function(require,module,exports){
 // 19.1.3.19 Object.setPrototypeOf(O, proto)
 var $export = require('./_export');
 $export($export.S, 'Object', { setPrototypeOf: require('./_set-proto').set });
 
-},{"./_export":53,"./_set-proto":87}],111:[function(require,module,exports){
+},{"./_export":58,"./_set-proto":92}],118:[function(require,module,exports){
 
-},{}],112:[function(require,module,exports){
+},{}],119:[function(require,module,exports){
 'use strict';
 var $at = require('./_string-at')(true);
 
@@ -2483,7 +2620,7 @@ require('./_iter-define')(String, 'String', function (iterated) {
   return { value: point, done: false };
 });
 
-},{"./_iter-define":66,"./_string-at":91}],113:[function(require,module,exports){
+},{"./_iter-define":71,"./_string-at":96}],120:[function(require,module,exports){
 'use strict';
 // ECMAScript 6 symbols shim
 var global = require('./_global');
@@ -2719,13 +2856,13 @@ setToStringTag(Math, 'Math', true);
 // 24.3.3 JSON[@@toStringTag]
 setToStringTag(global.JSON, 'JSON', true);
 
-},{"./_an-object":41,"./_descriptors":49,"./_enum-keys":52,"./_export":53,"./_fails":54,"./_global":55,"./_has":56,"./_hide":57,"./_is-array":62,"./_library":70,"./_meta":71,"./_object-create":73,"./_object-dp":74,"./_object-gopd":76,"./_object-gopn":78,"./_object-gopn-ext":77,"./_object-gops":79,"./_object-keys":82,"./_object-pie":83,"./_property-desc":85,"./_redefine":86,"./_set-to-string-tag":88,"./_shared":90,"./_to-iobject":94,"./_to-primitive":97,"./_uid":98,"./_wks":101,"./_wks-define":99,"./_wks-ext":100}],114:[function(require,module,exports){
+},{"./_an-object":46,"./_descriptors":54,"./_enum-keys":57,"./_export":58,"./_fails":59,"./_global":60,"./_has":61,"./_hide":62,"./_is-array":67,"./_library":75,"./_meta":76,"./_object-create":78,"./_object-dp":79,"./_object-gopd":81,"./_object-gopn":83,"./_object-gopn-ext":82,"./_object-gops":84,"./_object-keys":87,"./_object-pie":88,"./_property-desc":90,"./_redefine":91,"./_set-to-string-tag":93,"./_shared":95,"./_to-iobject":99,"./_to-primitive":102,"./_uid":103,"./_wks":106,"./_wks-define":104,"./_wks-ext":105}],121:[function(require,module,exports){
 require('./_wks-define')('asyncIterator');
 
-},{"./_wks-define":99}],115:[function(require,module,exports){
+},{"./_wks-define":104}],122:[function(require,module,exports){
 require('./_wks-define')('observable');
 
-},{"./_wks-define":99}],116:[function(require,module,exports){
+},{"./_wks-define":104}],123:[function(require,module,exports){
 require('./es6.array.iterator');
 var global = require('./_global');
 var hide = require('./_hide');
@@ -2746,7 +2883,7 @@ for (var i = 0; i < DOMIterables.length; i++) {
   Iterators[NAME] = Iterators.Array;
 }
 
-},{"./_global":55,"./_hide":57,"./_iterators":69,"./_wks":101,"./es6.array.iterator":104}],117:[function(require,module,exports){
+},{"./_global":60,"./_hide":62,"./_iterators":74,"./_wks":106,"./es6.array.iterator":111}],124:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -3620,7 +3757,7 @@ function factory(ReactComponent, isValidElement, ReactNoopUpdateQueue) {
 module.exports = factory;
 
 }).call(this,require('_process'))
-},{"_process":146,"fbjs/lib/emptyObject":127,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"object-assign":145}],118:[function(require,module,exports){
+},{"_process":153,"fbjs/lib/emptyObject":134,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"object-assign":152}],125:[function(require,module,exports){
 (function() {
   var base64map
       = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',
@@ -3718,7 +3855,7 @@ module.exports = factory;
   module.exports = crypt;
 })();
 
-},{}],119:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -3795,7 +3932,7 @@ var EventListener = {
 
 module.exports = EventListener;
 }).call(this,require('_process'))
-},{"./emptyFunction":126,"_process":146}],120:[function(require,module,exports){
+},{"./emptyFunction":133,"_process":153}],127:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -3829,7 +3966,7 @@ var ExecutionEnvironment = {
 };
 
 module.exports = ExecutionEnvironment;
-},{}],121:[function(require,module,exports){
+},{}],128:[function(require,module,exports){
 "use strict";
 
 /**
@@ -3859,7 +3996,7 @@ function camelize(string) {
 }
 
 module.exports = camelize;
-},{}],122:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -3897,7 +4034,7 @@ function camelizeStyleName(string) {
 }
 
 module.exports = camelizeStyleName;
-},{"./camelize":121}],123:[function(require,module,exports){
+},{"./camelize":128}],130:[function(require,module,exports){
 'use strict';
 
 /**
@@ -3935,7 +4072,7 @@ function containsNode(outerNode, innerNode) {
 }
 
 module.exports = containsNode;
-},{"./isTextNode":136}],124:[function(require,module,exports){
+},{"./isTextNode":143}],131:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -4062,7 +4199,7 @@ function createArrayFromMixed(obj) {
 
 module.exports = createArrayFromMixed;
 }).call(this,require('_process'))
-},{"./invariant":134,"_process":146}],125:[function(require,module,exports){
+},{"./invariant":141,"_process":153}],132:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -4146,7 +4283,7 @@ function createNodesFromMarkup(markup, handleScript) {
 
 module.exports = createNodesFromMarkup;
 }).call(this,require('_process'))
-},{"./ExecutionEnvironment":120,"./createArrayFromMixed":124,"./getMarkupWrap":130,"./invariant":134,"_process":146}],126:[function(require,module,exports){
+},{"./ExecutionEnvironment":127,"./createArrayFromMixed":131,"./getMarkupWrap":137,"./invariant":141,"_process":153}],133:[function(require,module,exports){
 "use strict";
 
 /**
@@ -4183,7 +4320,7 @@ emptyFunction.thatReturnsArgument = function (arg) {
 };
 
 module.exports = emptyFunction;
-},{}],127:[function(require,module,exports){
+},{}],134:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -4203,7 +4340,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = emptyObject;
 }).call(this,require('_process'))
-},{"_process":146}],128:[function(require,module,exports){
+},{"_process":153}],135:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4228,7 +4365,7 @@ function focusNode(node) {
 }
 
 module.exports = focusNode;
-},{}],129:[function(require,module,exports){
+},{}],136:[function(require,module,exports){
 'use strict';
 
 /**
@@ -4265,7 +4402,7 @@ function getActiveElement(doc) /*?DOMElement*/{
 }
 
 module.exports = getActiveElement;
-},{}],130:[function(require,module,exports){
+},{}],137:[function(require,module,exports){
 (function (process){
 'use strict';
 
@@ -4360,7 +4497,7 @@ function getMarkupWrap(nodeName) {
 
 module.exports = getMarkupWrap;
 }).call(this,require('_process'))
-},{"./ExecutionEnvironment":120,"./invariant":134,"_process":146}],131:[function(require,module,exports){
+},{"./ExecutionEnvironment":127,"./invariant":141,"_process":153}],138:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4397,7 +4534,7 @@ function getUnboundedScrollPosition(scrollable) {
 }
 
 module.exports = getUnboundedScrollPosition;
-},{}],132:[function(require,module,exports){
+},{}],139:[function(require,module,exports){
 'use strict';
 
 /**
@@ -4428,7 +4565,7 @@ function hyphenate(string) {
 }
 
 module.exports = hyphenate;
-},{}],133:[function(require,module,exports){
+},{}],140:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4465,7 +4602,7 @@ function hyphenateStyleName(string) {
 }
 
 module.exports = hyphenateStyleName;
-},{"./hyphenate":132}],134:[function(require,module,exports){
+},{"./hyphenate":139}],141:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -4521,7 +4658,7 @@ function invariant(condition, format, a, b, c, d, e, f) {
 
 module.exports = invariant;
 }).call(this,require('_process'))
-},{"_process":146}],135:[function(require,module,exports){
+},{"_process":153}],142:[function(require,module,exports){
 'use strict';
 
 /**
@@ -4544,7 +4681,7 @@ function isNode(object) {
 }
 
 module.exports = isNode;
-},{}],136:[function(require,module,exports){
+},{}],143:[function(require,module,exports){
 'use strict';
 
 /**
@@ -4567,7 +4704,7 @@ function isTextNode(object) {
 }
 
 module.exports = isTextNode;
-},{"./isNode":135}],137:[function(require,module,exports){
+},{"./isNode":142}],144:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4595,7 +4732,7 @@ function memoizeStringOnly(callback) {
 }
 
 module.exports = memoizeStringOnly;
-},{}],138:[function(require,module,exports){
+},{}],145:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4616,7 +4753,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 module.exports = performance || {};
-},{"./ExecutionEnvironment":120}],139:[function(require,module,exports){
+},{"./ExecutionEnvironment":127}],146:[function(require,module,exports){
 'use strict';
 
 /**
@@ -4648,7 +4785,7 @@ if (performance.now) {
 }
 
 module.exports = performanceNow;
-},{"./performance":138}],140:[function(require,module,exports){
+},{"./performance":145}],147:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -4714,7 +4851,7 @@ function shallowEqual(objA, objB) {
 }
 
 module.exports = shallowEqual;
-},{}],141:[function(require,module,exports){
+},{}],148:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -4779,7 +4916,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = warning;
 }).call(this,require('_process'))
-},{"./emptyFunction":126,"_process":146}],142:[function(require,module,exports){
+},{"./emptyFunction":133,"_process":153}],149:[function(require,module,exports){
 /*!
  * Determine if an object is a Buffer
  *
@@ -4802,7 +4939,7 @@ function isSlowBuffer (obj) {
   return typeof obj.readFloatLE === 'function' && typeof obj.slice === 'function' && isBuffer(obj.slice(0, 0))
 }
 
-},{}],143:[function(require,module,exports){
+},{}],150:[function(require,module,exports){
 module.exports = function() {
   var mediaQuery;
   if (typeof window !== "undefined" && window !== null) {
@@ -4817,7 +4954,7 @@ module.exports = function() {
   return false;
 };
 
-},{}],144:[function(require,module,exports){
+},{}],151:[function(require,module,exports){
 (function(){
   var crypt = require('crypt'),
       utf8 = require('charenc').utf8,
@@ -4979,7 +5116,7 @@ module.exports = function() {
 
 })();
 
-},{"charenc":29,"crypt":118,"is-buffer":142}],145:[function(require,module,exports){
+},{"charenc":32,"crypt":125,"is-buffer":149}],152:[function(require,module,exports){
 /*
 object-assign
 (c) Sindre Sorhus
@@ -5071,7 +5208,7 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 	return to;
 };
 
-},{}],146:[function(require,module,exports){
+},{}],153:[function(require,module,exports){
 // shim for using process in browser
 var process = module.exports = {};
 
@@ -5257,7 +5394,7 @@ process.chdir = function (dir) {
 };
 process.umask = function() { return 0; };
 
-},{}],147:[function(require,module,exports){
+},{}],154:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -5320,7 +5457,7 @@ function checkPropTypes(typeSpecs, values, location, componentName, getStack) {
 module.exports = checkPropTypes;
 
 }).call(this,require('_process'))
-},{"./lib/ReactPropTypesSecret":152,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141}],148:[function(require,module,exports){
+},{"./lib/ReactPropTypesSecret":159,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148}],155:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -5341,7 +5478,7 @@ module.exports = function(isValidElement) {
   return factory(isValidElement, throwOnDirectAccess);
 };
 
-},{"./factoryWithTypeCheckers":150}],149:[function(require,module,exports){
+},{"./factoryWithTypeCheckers":157}],156:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -5401,7 +5538,7 @@ module.exports = function() {
   return ReactPropTypes;
 };
 
-},{"./lib/ReactPropTypesSecret":152,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134}],150:[function(require,module,exports){
+},{"./lib/ReactPropTypesSecret":159,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141}],157:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -5947,7 +6084,7 @@ module.exports = function(isValidElement, throwOnDirectAccess) {
 };
 
 }).call(this,require('_process'))
-},{"./checkPropTypes":147,"./lib/ReactPropTypesSecret":152,"_process":146,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"object-assign":145}],151:[function(require,module,exports){
+},{"./checkPropTypes":154,"./lib/ReactPropTypesSecret":159,"_process":153,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"object-assign":152}],158:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -5979,7 +6116,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 }).call(this,require('_process'))
-},{"./factoryWithThrowingShims":149,"./factoryWithTypeCheckers":150,"_process":146}],152:[function(require,module,exports){
+},{"./factoryWithThrowingShims":156,"./factoryWithTypeCheckers":157,"_process":153}],159:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -5993,12 +6130,12 @@ var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 
 module.exports = ReactPropTypesSecret;
 
-},{}],153:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
 'use strict';
 
 module.exports = require('./lib/ReactDOM');
 
-},{"./lib/ReactDOM":183}],154:[function(require,module,exports){
+},{"./lib/ReactDOM":190}],161:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -6070,7 +6207,7 @@ var ARIADOMPropertyConfig = {
 };
 
 module.exports = ARIADOMPropertyConfig;
-},{}],155:[function(require,module,exports){
+},{}],162:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -6092,7 +6229,7 @@ var AutoFocusUtils = {
 };
 
 module.exports = AutoFocusUtils;
-},{"./ReactDOMComponentTree":186,"fbjs/lib/focusNode":128}],156:[function(require,module,exports){
+},{"./ReactDOMComponentTree":193,"fbjs/lib/focusNode":135}],163:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -6474,7 +6611,7 @@ var BeforeInputEventPlugin = {
 };
 
 module.exports = BeforeInputEventPlugin;
-},{"./EventPropagators":172,"./FallbackCompositionState":173,"./SyntheticCompositionEvent":237,"./SyntheticInputEvent":241,"fbjs/lib/ExecutionEnvironment":120}],157:[function(require,module,exports){
+},{"./EventPropagators":179,"./FallbackCompositionState":180,"./SyntheticCompositionEvent":244,"./SyntheticInputEvent":248,"fbjs/lib/ExecutionEnvironment":127}],164:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -6627,7 +6764,7 @@ var CSSProperty = {
 };
 
 module.exports = CSSProperty;
-},{}],158:[function(require,module,exports){
+},{}],165:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -6842,7 +6979,7 @@ var CSSPropertyOperations = {
 
 module.exports = CSSPropertyOperations;
 }).call(this,require('_process'))
-},{"./CSSProperty":157,"./ReactInstrumentation":215,"./dangerousStyleValue":254,"_process":146,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/camelizeStyleName":122,"fbjs/lib/hyphenateStyleName":133,"fbjs/lib/memoizeStringOnly":137,"fbjs/lib/warning":141}],159:[function(require,module,exports){
+},{"./CSSProperty":164,"./ReactInstrumentation":222,"./dangerousStyleValue":261,"_process":153,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/camelizeStyleName":129,"fbjs/lib/hyphenateStyleName":140,"fbjs/lib/memoizeStringOnly":144,"fbjs/lib/warning":148}],166:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -6961,7 +7098,7 @@ var CallbackQueue = function () {
 
 module.exports = PooledClass.addPoolingTo(CallbackQueue);
 }).call(this,require('_process'))
-},{"./PooledClass":177,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],160:[function(require,module,exports){
+},{"./PooledClass":184,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],167:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -7271,7 +7408,7 @@ var ChangeEventPlugin = {
 };
 
 module.exports = ChangeEventPlugin;
-},{"./EventPluginHub":169,"./EventPropagators":172,"./ReactDOMComponentTree":186,"./ReactUpdates":230,"./SyntheticEvent":239,"./getEventTarget":262,"./inputValueTracking":268,"./isEventSupported":270,"./isTextInputElement":271,"fbjs/lib/ExecutionEnvironment":120}],161:[function(require,module,exports){
+},{"./EventPluginHub":176,"./EventPropagators":179,"./ReactDOMComponentTree":193,"./ReactUpdates":237,"./SyntheticEvent":246,"./getEventTarget":269,"./inputValueTracking":275,"./isEventSupported":277,"./isTextInputElement":278,"fbjs/lib/ExecutionEnvironment":127}],168:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -7497,7 +7634,7 @@ var DOMChildrenOperations = {
 
 module.exports = DOMChildrenOperations;
 }).call(this,require('_process'))
-},{"./DOMLazyTree":162,"./Danger":166,"./ReactDOMComponentTree":186,"./ReactInstrumentation":215,"./createMicrosoftUnsafeLocalFunction":253,"./setInnerHTML":275,"./setTextContent":276,"_process":146}],162:[function(require,module,exports){
+},{"./DOMLazyTree":169,"./Danger":173,"./ReactDOMComponentTree":193,"./ReactInstrumentation":222,"./createMicrosoftUnsafeLocalFunction":260,"./setInnerHTML":282,"./setTextContent":283,"_process":153}],169:[function(require,module,exports){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  *
@@ -7613,7 +7750,7 @@ DOMLazyTree.queueHTML = queueHTML;
 DOMLazyTree.queueText = queueText;
 
 module.exports = DOMLazyTree;
-},{"./DOMNamespaces":163,"./createMicrosoftUnsafeLocalFunction":253,"./setInnerHTML":275,"./setTextContent":276}],163:[function(require,module,exports){
+},{"./DOMNamespaces":170,"./createMicrosoftUnsafeLocalFunction":260,"./setInnerHTML":282,"./setTextContent":283}],170:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -7631,7 +7768,7 @@ var DOMNamespaces = {
 };
 
 module.exports = DOMNamespaces;
-},{}],164:[function(require,module,exports){
+},{}],171:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -7840,7 +7977,7 @@ var DOMProperty = {
 
 module.exports = DOMProperty;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],165:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],172:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -8075,7 +8212,7 @@ var DOMPropertyOperations = {
 
 module.exports = DOMPropertyOperations;
 }).call(this,require('_process'))
-},{"./DOMProperty":164,"./ReactDOMComponentTree":186,"./ReactInstrumentation":215,"./quoteAttributeValueForBrowser":272,"_process":146,"fbjs/lib/warning":141}],166:[function(require,module,exports){
+},{"./DOMProperty":171,"./ReactDOMComponentTree":193,"./ReactInstrumentation":222,"./quoteAttributeValueForBrowser":279,"_process":153,"fbjs/lib/warning":148}],173:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -8121,7 +8258,7 @@ var Danger = {
 
 module.exports = Danger;
 }).call(this,require('_process'))
-},{"./DOMLazyTree":162,"./reactProdInvariant":273,"_process":146,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/createNodesFromMarkup":125,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134}],167:[function(require,module,exports){
+},{"./DOMLazyTree":169,"./reactProdInvariant":280,"_process":153,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/createNodesFromMarkup":132,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141}],174:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -8145,7 +8282,7 @@ module.exports = Danger;
 var DefaultEventPluginOrder = ['ResponderEventPlugin', 'SimpleEventPlugin', 'TapEventPlugin', 'EnterLeaveEventPlugin', 'ChangeEventPlugin', 'SelectEventPlugin', 'BeforeInputEventPlugin'];
 
 module.exports = DefaultEventPluginOrder;
-},{}],168:[function(require,module,exports){
+},{}],175:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -8241,7 +8378,7 @@ var EnterLeaveEventPlugin = {
 };
 
 module.exports = EnterLeaveEventPlugin;
-},{"./EventPropagators":172,"./ReactDOMComponentTree":186,"./SyntheticMouseEvent":243}],169:[function(require,module,exports){
+},{"./EventPropagators":179,"./ReactDOMComponentTree":193,"./SyntheticMouseEvent":250}],176:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -8515,7 +8652,7 @@ var EventPluginHub = {
 
 module.exports = EventPluginHub;
 }).call(this,require('_process'))
-},{"./EventPluginRegistry":170,"./EventPluginUtils":171,"./ReactErrorUtils":206,"./accumulateInto":250,"./forEachAccumulated":258,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],170:[function(require,module,exports){
+},{"./EventPluginRegistry":177,"./EventPluginUtils":178,"./ReactErrorUtils":213,"./accumulateInto":257,"./forEachAccumulated":265,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],177:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -8768,7 +8905,7 @@ var EventPluginRegistry = {
 
 module.exports = EventPluginRegistry;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],171:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],178:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -8994,7 +9131,7 @@ var EventPluginUtils = {
 
 module.exports = EventPluginUtils;
 }).call(this,require('_process'))
-},{"./ReactErrorUtils":206,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141}],172:[function(require,module,exports){
+},{"./ReactErrorUtils":213,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148}],179:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -9128,7 +9265,7 @@ var EventPropagators = {
 
 module.exports = EventPropagators;
 }).call(this,require('_process'))
-},{"./EventPluginHub":169,"./EventPluginUtils":171,"./accumulateInto":250,"./forEachAccumulated":258,"_process":146,"fbjs/lib/warning":141}],173:[function(require,module,exports){
+},{"./EventPluginHub":176,"./EventPluginUtils":178,"./accumulateInto":257,"./forEachAccumulated":265,"_process":153,"fbjs/lib/warning":148}],180:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -9221,7 +9358,7 @@ _assign(FallbackCompositionState.prototype, {
 PooledClass.addPoolingTo(FallbackCompositionState);
 
 module.exports = FallbackCompositionState;
-},{"./PooledClass":177,"./getTextContentAccessor":266,"object-assign":145}],174:[function(require,module,exports){
+},{"./PooledClass":184,"./getTextContentAccessor":273,"object-assign":152}],181:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -9456,7 +9593,7 @@ var HTMLDOMPropertyConfig = {
 };
 
 module.exports = HTMLDOMPropertyConfig;
-},{"./DOMProperty":164}],175:[function(require,module,exports){
+},{"./DOMProperty":171}],182:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -9513,7 +9650,7 @@ var KeyEscapeUtils = {
 };
 
 module.exports = KeyEscapeUtils;
-},{}],176:[function(require,module,exports){
+},{}],183:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -9651,7 +9788,7 @@ var LinkedValueUtils = {
 
 module.exports = LinkedValueUtils;
 }).call(this,require('_process'))
-},{"./ReactPropTypesSecret":223,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"prop-types/factory":148,"react/lib/React":282}],177:[function(require,module,exports){
+},{"./ReactPropTypesSecret":230,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"prop-types/factory":155,"react/lib/React":289}],184:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -9763,7 +9900,7 @@ var PooledClass = {
 
 module.exports = PooledClass;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],178:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],185:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -10085,7 +10222,7 @@ var ReactBrowserEventEmitter = _assign({}, ReactEventEmitterMixin, {
 });
 
 module.exports = ReactBrowserEventEmitter;
-},{"./EventPluginRegistry":170,"./ReactEventEmitterMixin":207,"./ViewportMetrics":249,"./getVendorPrefixedEventName":267,"./isEventSupported":270,"object-assign":145}],179:[function(require,module,exports){
+},{"./EventPluginRegistry":177,"./ReactEventEmitterMixin":214,"./ViewportMetrics":256,"./getVendorPrefixedEventName":274,"./isEventSupported":277,"object-assign":152}],186:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -10238,7 +10375,7 @@ var ReactChildReconciler = {
 
 module.exports = ReactChildReconciler;
 }).call(this,require('_process'))
-},{"./KeyEscapeUtils":175,"./ReactReconciler":225,"./instantiateReactComponent":269,"./shouldUpdateReactComponent":277,"./traverseAllChildren":278,"_process":146,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],180:[function(require,module,exports){
+},{"./KeyEscapeUtils":182,"./ReactReconciler":232,"./instantiateReactComponent":276,"./shouldUpdateReactComponent":284,"./traverseAllChildren":285,"_process":153,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],187:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -10264,7 +10401,7 @@ var ReactComponentBrowserEnvironment = {
 };
 
 module.exports = ReactComponentBrowserEnvironment;
-},{"./DOMChildrenOperations":161,"./ReactDOMIDOperations":190}],181:[function(require,module,exports){
+},{"./DOMChildrenOperations":168,"./ReactDOMIDOperations":197}],188:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -10308,7 +10445,7 @@ var ReactComponentEnvironment = {
 
 module.exports = ReactComponentEnvironment;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],182:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],189:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -11208,7 +11345,7 @@ var ReactCompositeComponent = {
 
 module.exports = ReactCompositeComponent;
 }).call(this,require('_process'))
-},{"./ReactComponentEnvironment":181,"./ReactErrorUtils":206,"./ReactInstanceMap":214,"./ReactInstrumentation":215,"./ReactNodeTypes":220,"./ReactReconciler":225,"./checkReactTypeSpec":252,"./reactProdInvariant":273,"./shouldUpdateReactComponent":277,"_process":146,"fbjs/lib/emptyObject":127,"fbjs/lib/invariant":134,"fbjs/lib/shallowEqual":140,"fbjs/lib/warning":141,"object-assign":145,"react/lib/React":282,"react/lib/ReactCurrentOwner":286}],183:[function(require,module,exports){
+},{"./ReactComponentEnvironment":188,"./ReactErrorUtils":213,"./ReactInstanceMap":221,"./ReactInstrumentation":222,"./ReactNodeTypes":227,"./ReactReconciler":232,"./checkReactTypeSpec":259,"./reactProdInvariant":280,"./shouldUpdateReactComponent":284,"_process":153,"fbjs/lib/emptyObject":134,"fbjs/lib/invariant":141,"fbjs/lib/shallowEqual":147,"fbjs/lib/warning":148,"object-assign":152,"react/lib/React":289,"react/lib/ReactCurrentOwner":293}],190:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -11319,7 +11456,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = ReactDOM;
 }).call(this,require('_process'))
-},{"./ReactDOMComponentTree":186,"./ReactDOMInvalidARIAHook":192,"./ReactDOMNullInputValuePropHook":193,"./ReactDOMUnknownPropertyHook":200,"./ReactDefaultInjection":203,"./ReactInstrumentation":215,"./ReactMount":218,"./ReactReconciler":225,"./ReactUpdates":230,"./ReactVersion":231,"./findDOMNode":256,"./getHostComponentFromComposite":263,"./renderSubtreeIntoContainer":274,"_process":146,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/warning":141}],184:[function(require,module,exports){
+},{"./ReactDOMComponentTree":193,"./ReactDOMInvalidARIAHook":199,"./ReactDOMNullInputValuePropHook":200,"./ReactDOMUnknownPropertyHook":207,"./ReactDefaultInjection":210,"./ReactInstrumentation":222,"./ReactMount":225,"./ReactReconciler":232,"./ReactUpdates":237,"./ReactVersion":238,"./findDOMNode":263,"./getHostComponentFromComposite":270,"./renderSubtreeIntoContainer":281,"_process":153,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/warning":148}],191:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -12333,7 +12470,7 @@ _assign(ReactDOMComponent.prototype, ReactDOMComponent.Mixin, ReactMultiChild.Mi
 
 module.exports = ReactDOMComponent;
 }).call(this,require('_process'))
-},{"./AutoFocusUtils":155,"./CSSPropertyOperations":158,"./DOMLazyTree":162,"./DOMNamespaces":163,"./DOMProperty":164,"./DOMPropertyOperations":165,"./EventPluginHub":169,"./EventPluginRegistry":170,"./ReactBrowserEventEmitter":178,"./ReactDOMComponentFlags":185,"./ReactDOMComponentTree":186,"./ReactDOMInput":191,"./ReactDOMOption":194,"./ReactDOMSelect":195,"./ReactDOMTextarea":198,"./ReactInstrumentation":215,"./ReactMultiChild":219,"./ReactServerRenderingTransaction":227,"./escapeTextContentForBrowser":255,"./inputValueTracking":268,"./isEventSupported":270,"./reactProdInvariant":273,"./validateDOMNesting":279,"_process":146,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134,"fbjs/lib/shallowEqual":140,"fbjs/lib/warning":141,"object-assign":145}],185:[function(require,module,exports){
+},{"./AutoFocusUtils":162,"./CSSPropertyOperations":165,"./DOMLazyTree":169,"./DOMNamespaces":170,"./DOMProperty":171,"./DOMPropertyOperations":172,"./EventPluginHub":176,"./EventPluginRegistry":177,"./ReactBrowserEventEmitter":185,"./ReactDOMComponentFlags":192,"./ReactDOMComponentTree":193,"./ReactDOMInput":198,"./ReactDOMOption":201,"./ReactDOMSelect":202,"./ReactDOMTextarea":205,"./ReactInstrumentation":222,"./ReactMultiChild":226,"./ReactServerRenderingTransaction":234,"./escapeTextContentForBrowser":262,"./inputValueTracking":275,"./isEventSupported":277,"./reactProdInvariant":280,"./validateDOMNesting":286,"_process":153,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141,"fbjs/lib/shallowEqual":147,"fbjs/lib/warning":148,"object-assign":152}],192:[function(require,module,exports){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  *
@@ -12349,7 +12486,7 @@ var ReactDOMComponentFlags = {
 };
 
 module.exports = ReactDOMComponentFlags;
-},{}],186:[function(require,module,exports){
+},{}],193:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -12544,7 +12681,7 @@ var ReactDOMComponentTree = {
 
 module.exports = ReactDOMComponentTree;
 }).call(this,require('_process'))
-},{"./DOMProperty":164,"./ReactDOMComponentFlags":185,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],187:[function(require,module,exports){
+},{"./DOMProperty":171,"./ReactDOMComponentFlags":192,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],194:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -12577,7 +12714,7 @@ function ReactDOMContainerInfo(topLevelWrapper, node) {
 
 module.exports = ReactDOMContainerInfo;
 }).call(this,require('_process'))
-},{"./validateDOMNesting":279,"_process":146}],188:[function(require,module,exports){
+},{"./validateDOMNesting":286,"_process":153}],195:[function(require,module,exports){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  *
@@ -12635,7 +12772,7 @@ _assign(ReactDOMEmptyComponent.prototype, {
 });
 
 module.exports = ReactDOMEmptyComponent;
-},{"./DOMLazyTree":162,"./ReactDOMComponentTree":186,"object-assign":145}],189:[function(require,module,exports){
+},{"./DOMLazyTree":169,"./ReactDOMComponentTree":193,"object-assign":152}],196:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -12652,7 +12789,7 @@ var ReactDOMFeatureFlags = {
 };
 
 module.exports = ReactDOMFeatureFlags;
-},{}],190:[function(require,module,exports){
+},{}],197:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -12683,7 +12820,7 @@ var ReactDOMIDOperations = {
 };
 
 module.exports = ReactDOMIDOperations;
-},{"./DOMChildrenOperations":161,"./ReactDOMComponentTree":186}],191:[function(require,module,exports){
+},{"./DOMChildrenOperations":168,"./ReactDOMComponentTree":193}],198:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -12970,7 +13107,7 @@ function _handleChange(event) {
 
 module.exports = ReactDOMInput;
 }).call(this,require('_process'))
-},{"./DOMPropertyOperations":165,"./LinkedValueUtils":176,"./ReactDOMComponentTree":186,"./ReactUpdates":230,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"object-assign":145}],192:[function(require,module,exports){
+},{"./DOMPropertyOperations":172,"./LinkedValueUtils":183,"./ReactDOMComponentTree":193,"./ReactUpdates":237,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"object-assign":152}],199:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13063,7 +13200,7 @@ var ReactDOMInvalidARIAHook = {
 
 module.exports = ReactDOMInvalidARIAHook;
 }).call(this,require('_process'))
-},{"./DOMProperty":164,"_process":146,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],193:[function(require,module,exports){
+},{"./DOMProperty":171,"_process":153,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],200:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13106,7 +13243,7 @@ var ReactDOMNullInputValuePropHook = {
 
 module.exports = ReactDOMNullInputValuePropHook;
 }).call(this,require('_process'))
-},{"_process":146,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],194:[function(require,module,exports){
+},{"_process":153,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],201:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13228,7 +13365,7 @@ var ReactDOMOption = {
 
 module.exports = ReactDOMOption;
 }).call(this,require('_process'))
-},{"./ReactDOMComponentTree":186,"./ReactDOMSelect":195,"_process":146,"fbjs/lib/warning":141,"object-assign":145,"react/lib/React":282}],195:[function(require,module,exports){
+},{"./ReactDOMComponentTree":193,"./ReactDOMSelect":202,"_process":153,"fbjs/lib/warning":148,"object-assign":152,"react/lib/React":289}],202:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13428,7 +13565,7 @@ function _handleChange(event) {
 
 module.exports = ReactDOMSelect;
 }).call(this,require('_process'))
-},{"./LinkedValueUtils":176,"./ReactDOMComponentTree":186,"./ReactUpdates":230,"_process":146,"fbjs/lib/warning":141,"object-assign":145}],196:[function(require,module,exports){
+},{"./LinkedValueUtils":183,"./ReactDOMComponentTree":193,"./ReactUpdates":237,"_process":153,"fbjs/lib/warning":148,"object-assign":152}],203:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -13638,7 +13775,7 @@ var ReactDOMSelection = {
 };
 
 module.exports = ReactDOMSelection;
-},{"./getNodeForCharacterOffset":265,"./getTextContentAccessor":266,"fbjs/lib/ExecutionEnvironment":120}],197:[function(require,module,exports){
+},{"./getNodeForCharacterOffset":272,"./getTextContentAccessor":273,"fbjs/lib/ExecutionEnvironment":127}],204:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13800,7 +13937,7 @@ _assign(ReactDOMTextComponent.prototype, {
 
 module.exports = ReactDOMTextComponent;
 }).call(this,require('_process'))
-},{"./DOMChildrenOperations":161,"./DOMLazyTree":162,"./ReactDOMComponentTree":186,"./escapeTextContentForBrowser":255,"./reactProdInvariant":273,"./validateDOMNesting":279,"_process":146,"fbjs/lib/invariant":134,"object-assign":145}],198:[function(require,module,exports){
+},{"./DOMChildrenOperations":168,"./DOMLazyTree":169,"./ReactDOMComponentTree":193,"./escapeTextContentForBrowser":262,"./reactProdInvariant":280,"./validateDOMNesting":286,"_process":153,"fbjs/lib/invariant":141,"object-assign":152}],205:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -13960,7 +14097,7 @@ function _handleChange(event) {
 
 module.exports = ReactDOMTextarea;
 }).call(this,require('_process'))
-},{"./LinkedValueUtils":176,"./ReactDOMComponentTree":186,"./ReactUpdates":230,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"object-assign":145}],199:[function(require,module,exports){
+},{"./LinkedValueUtils":183,"./ReactDOMComponentTree":193,"./ReactUpdates":237,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"object-assign":152}],206:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -14096,7 +14233,7 @@ module.exports = {
   traverseEnterLeave: traverseEnterLeave
 };
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],200:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],207:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -14208,7 +14345,7 @@ var ReactDOMUnknownPropertyHook = {
 
 module.exports = ReactDOMUnknownPropertyHook;
 }).call(this,require('_process'))
-},{"./DOMProperty":164,"./EventPluginRegistry":170,"_process":146,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],201:[function(require,module,exports){
+},{"./DOMProperty":171,"./EventPluginRegistry":177,"_process":153,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],208:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
@@ -14569,7 +14706,7 @@ if (/[?&]react_perf\b/.test(url)) {
 
 module.exports = ReactDebugTool;
 }).call(this,require('_process'))
-},{"./ReactHostOperationHistoryHook":211,"./ReactInvalidSetStateWarningHook":216,"_process":146,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/performanceNow":139,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],202:[function(require,module,exports){
+},{"./ReactHostOperationHistoryHook":218,"./ReactInvalidSetStateWarningHook":223,"_process":153,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/performanceNow":146,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],209:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -14635,7 +14772,7 @@ var ReactDefaultBatchingStrategy = {
 };
 
 module.exports = ReactDefaultBatchingStrategy;
-},{"./ReactUpdates":230,"./Transaction":248,"fbjs/lib/emptyFunction":126,"object-assign":145}],203:[function(require,module,exports){
+},{"./ReactUpdates":237,"./Transaction":255,"fbjs/lib/emptyFunction":133,"object-assign":152}],210:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -14719,7 +14856,7 @@ function inject() {
 module.exports = {
   inject: inject
 };
-},{"./ARIADOMPropertyConfig":154,"./BeforeInputEventPlugin":156,"./ChangeEventPlugin":160,"./DefaultEventPluginOrder":167,"./EnterLeaveEventPlugin":168,"./HTMLDOMPropertyConfig":174,"./ReactComponentBrowserEnvironment":180,"./ReactDOMComponent":184,"./ReactDOMComponentTree":186,"./ReactDOMEmptyComponent":188,"./ReactDOMTextComponent":197,"./ReactDOMTreeTraversal":199,"./ReactDefaultBatchingStrategy":202,"./ReactEventListener":208,"./ReactInjection":212,"./ReactReconcileTransaction":224,"./SVGDOMPropertyConfig":232,"./SelectEventPlugin":233,"./SimpleEventPlugin":234}],204:[function(require,module,exports){
+},{"./ARIADOMPropertyConfig":161,"./BeforeInputEventPlugin":163,"./ChangeEventPlugin":167,"./DefaultEventPluginOrder":174,"./EnterLeaveEventPlugin":175,"./HTMLDOMPropertyConfig":181,"./ReactComponentBrowserEnvironment":187,"./ReactDOMComponent":191,"./ReactDOMComponentTree":193,"./ReactDOMEmptyComponent":195,"./ReactDOMTextComponent":204,"./ReactDOMTreeTraversal":206,"./ReactDefaultBatchingStrategy":209,"./ReactEventListener":215,"./ReactInjection":219,"./ReactReconcileTransaction":231,"./SVGDOMPropertyConfig":239,"./SelectEventPlugin":240,"./SimpleEventPlugin":241}],211:[function(require,module,exports){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  *
@@ -14737,7 +14874,7 @@ module.exports = {
 var REACT_ELEMENT_TYPE = typeof Symbol === 'function' && Symbol['for'] && Symbol['for']('react.element') || 0xeac7;
 
 module.exports = REACT_ELEMENT_TYPE;
-},{}],205:[function(require,module,exports){
+},{}],212:[function(require,module,exports){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
  *
@@ -14765,7 +14902,7 @@ var ReactEmptyComponent = {
 ReactEmptyComponent.injection = ReactEmptyComponentInjection;
 
 module.exports = ReactEmptyComponent;
-},{}],206:[function(require,module,exports){
+},{}],213:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -14843,7 +14980,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = ReactErrorUtils;
 }).call(this,require('_process'))
-},{"_process":146}],207:[function(require,module,exports){
+},{"_process":153}],214:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -14873,7 +15010,7 @@ var ReactEventEmitterMixin = {
 };
 
 module.exports = ReactEventEmitterMixin;
-},{"./EventPluginHub":169}],208:[function(require,module,exports){
+},{"./EventPluginHub":176}],215:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15026,7 +15163,7 @@ var ReactEventListener = {
 };
 
 module.exports = ReactEventListener;
-},{"./PooledClass":177,"./ReactDOMComponentTree":186,"./ReactUpdates":230,"./getEventTarget":262,"fbjs/lib/EventListener":119,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/getUnboundedScrollPosition":131,"object-assign":145}],209:[function(require,module,exports){
+},{"./PooledClass":184,"./ReactDOMComponentTree":193,"./ReactUpdates":237,"./getEventTarget":269,"fbjs/lib/EventListener":126,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/getUnboundedScrollPosition":138,"object-assign":152}],216:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15046,7 +15183,7 @@ var ReactFeatureFlags = {
 };
 
 module.exports = ReactFeatureFlags;
-},{}],210:[function(require,module,exports){
+},{}],217:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -15114,7 +15251,7 @@ var ReactHostComponent = {
 
 module.exports = ReactHostComponent;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],211:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],218:[function(require,module,exports){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
  *
@@ -15146,7 +15283,7 @@ var ReactHostOperationHistoryHook = {
 };
 
 module.exports = ReactHostOperationHistoryHook;
-},{}],212:[function(require,module,exports){
+},{}],219:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15178,7 +15315,7 @@ var ReactInjection = {
 };
 
 module.exports = ReactInjection;
-},{"./DOMProperty":164,"./EventPluginHub":169,"./EventPluginUtils":171,"./ReactBrowserEventEmitter":178,"./ReactComponentEnvironment":181,"./ReactEmptyComponent":205,"./ReactHostComponent":210,"./ReactUpdates":230}],213:[function(require,module,exports){
+},{"./DOMProperty":171,"./EventPluginHub":176,"./EventPluginUtils":178,"./ReactBrowserEventEmitter":185,"./ReactComponentEnvironment":188,"./ReactEmptyComponent":212,"./ReactHostComponent":217,"./ReactUpdates":237}],220:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15299,7 +15436,7 @@ var ReactInputSelection = {
 };
 
 module.exports = ReactInputSelection;
-},{"./ReactDOMSelection":196,"fbjs/lib/containsNode":123,"fbjs/lib/focusNode":128,"fbjs/lib/getActiveElement":129}],214:[function(require,module,exports){
+},{"./ReactDOMSelection":203,"fbjs/lib/containsNode":130,"fbjs/lib/focusNode":135,"fbjs/lib/getActiveElement":136}],221:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15343,7 +15480,7 @@ var ReactInstanceMap = {
 };
 
 module.exports = ReactInstanceMap;
-},{}],215:[function(require,module,exports){
+},{}],222:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
@@ -15367,7 +15504,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = { debugTool: debugTool };
 }).call(this,require('_process'))
-},{"./ReactDebugTool":201,"_process":146}],216:[function(require,module,exports){
+},{"./ReactDebugTool":208,"_process":153}],223:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
@@ -15404,7 +15541,7 @@ var ReactInvalidSetStateWarningHook = {
 
 module.exports = ReactInvalidSetStateWarningHook;
 }).call(this,require('_process'))
-},{"_process":146,"fbjs/lib/warning":141}],217:[function(require,module,exports){
+},{"_process":153,"fbjs/lib/warning":148}],224:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -15452,7 +15589,7 @@ var ReactMarkupChecksum = {
 };
 
 module.exports = ReactMarkupChecksum;
-},{"./adler32":251}],218:[function(require,module,exports){
+},{"./adler32":258}],225:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -15990,7 +16127,7 @@ var ReactMount = {
 
 module.exports = ReactMount;
 }).call(this,require('_process'))
-},{"./DOMLazyTree":162,"./DOMProperty":164,"./ReactBrowserEventEmitter":178,"./ReactDOMComponentTree":186,"./ReactDOMContainerInfo":187,"./ReactDOMFeatureFlags":189,"./ReactFeatureFlags":209,"./ReactInstanceMap":214,"./ReactInstrumentation":215,"./ReactMarkupChecksum":217,"./ReactReconciler":225,"./ReactUpdateQueue":229,"./ReactUpdates":230,"./instantiateReactComponent":269,"./reactProdInvariant":273,"./setInnerHTML":275,"./shouldUpdateReactComponent":277,"_process":146,"fbjs/lib/emptyObject":127,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"react/lib/React":282,"react/lib/ReactCurrentOwner":286}],219:[function(require,module,exports){
+},{"./DOMLazyTree":169,"./DOMProperty":171,"./ReactBrowserEventEmitter":185,"./ReactDOMComponentTree":193,"./ReactDOMContainerInfo":194,"./ReactDOMFeatureFlags":196,"./ReactFeatureFlags":216,"./ReactInstanceMap":221,"./ReactInstrumentation":222,"./ReactMarkupChecksum":224,"./ReactReconciler":232,"./ReactUpdateQueue":236,"./ReactUpdates":237,"./instantiateReactComponent":276,"./reactProdInvariant":280,"./setInnerHTML":282,"./shouldUpdateReactComponent":284,"_process":153,"fbjs/lib/emptyObject":134,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"react/lib/React":289,"react/lib/ReactCurrentOwner":293}],226:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16436,7 +16573,7 @@ var ReactMultiChild = {
 
 module.exports = ReactMultiChild;
 }).call(this,require('_process'))
-},{"./ReactChildReconciler":179,"./ReactComponentEnvironment":181,"./ReactInstanceMap":214,"./ReactInstrumentation":215,"./ReactReconciler":225,"./flattenChildren":257,"./reactProdInvariant":273,"_process":146,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134,"react/lib/ReactCurrentOwner":286}],220:[function(require,module,exports){
+},{"./ReactChildReconciler":186,"./ReactComponentEnvironment":188,"./ReactInstanceMap":221,"./ReactInstrumentation":222,"./ReactReconciler":232,"./flattenChildren":264,"./reactProdInvariant":280,"_process":153,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141,"react/lib/ReactCurrentOwner":293}],227:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16476,7 +16613,7 @@ var ReactNodeTypes = {
 
 module.exports = ReactNodeTypes;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"react/lib/React":282}],221:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"react/lib/React":289}],228:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16569,7 +16706,7 @@ var ReactOwner = {
 
 module.exports = ReactOwner;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],222:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],229:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16594,7 +16731,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = ReactPropTypeLocationNames;
 }).call(this,require('_process'))
-},{"_process":146}],223:[function(require,module,exports){
+},{"_process":153}],230:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -16609,7 +16746,7 @@ module.exports = ReactPropTypeLocationNames;
 var ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 
 module.exports = ReactPropTypesSecret;
-},{}],224:[function(require,module,exports){
+},{}],231:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16787,7 +16924,7 @@ PooledClass.addPoolingTo(ReactReconcileTransaction);
 
 module.exports = ReactReconcileTransaction;
 }).call(this,require('_process'))
-},{"./CallbackQueue":159,"./PooledClass":177,"./ReactBrowserEventEmitter":178,"./ReactInputSelection":213,"./ReactInstrumentation":215,"./ReactUpdateQueue":229,"./Transaction":248,"_process":146,"object-assign":145}],225:[function(require,module,exports){
+},{"./CallbackQueue":166,"./PooledClass":184,"./ReactBrowserEventEmitter":185,"./ReactInputSelection":220,"./ReactInstrumentation":222,"./ReactUpdateQueue":236,"./Transaction":255,"_process":153,"object-assign":152}],232:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -16953,7 +17090,7 @@ var ReactReconciler = {
 
 module.exports = ReactReconciler;
 }).call(this,require('_process'))
-},{"./ReactInstrumentation":215,"./ReactRef":226,"_process":146,"fbjs/lib/warning":141}],226:[function(require,module,exports){
+},{"./ReactInstrumentation":222,"./ReactRef":233,"_process":153,"fbjs/lib/warning":148}],233:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -17040,7 +17177,7 @@ ReactRef.detachRefs = function (instance, element) {
 };
 
 module.exports = ReactRef;
-},{"./ReactOwner":221}],227:[function(require,module,exports){
+},{"./ReactOwner":228}],234:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -17130,7 +17267,7 @@ PooledClass.addPoolingTo(ReactServerRenderingTransaction);
 
 module.exports = ReactServerRenderingTransaction;
 }).call(this,require('_process'))
-},{"./PooledClass":177,"./ReactInstrumentation":215,"./ReactServerUpdateQueue":228,"./Transaction":248,"_process":146,"object-assign":145}],228:[function(require,module,exports){
+},{"./PooledClass":184,"./ReactInstrumentation":222,"./ReactServerUpdateQueue":235,"./Transaction":255,"_process":153,"object-assign":152}],235:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -17269,7 +17406,7 @@ var ReactServerUpdateQueue = function () {
 
 module.exports = ReactServerUpdateQueue;
 }).call(this,require('_process'))
-},{"./ReactUpdateQueue":229,"_process":146,"fbjs/lib/warning":141}],229:[function(require,module,exports){
+},{"./ReactUpdateQueue":236,"_process":153,"fbjs/lib/warning":148}],236:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -17503,7 +17640,7 @@ var ReactUpdateQueue = {
 
 module.exports = ReactUpdateQueue;
 }).call(this,require('_process'))
-},{"./ReactInstanceMap":214,"./ReactInstrumentation":215,"./ReactUpdates":230,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"react/lib/ReactCurrentOwner":286}],230:[function(require,module,exports){
+},{"./ReactInstanceMap":221,"./ReactInstrumentation":222,"./ReactUpdates":237,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"react/lib/ReactCurrentOwner":293}],237:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -17754,7 +17891,7 @@ var ReactUpdates = {
 
 module.exports = ReactUpdates;
 }).call(this,require('_process'))
-},{"./CallbackQueue":159,"./PooledClass":177,"./ReactFeatureFlags":209,"./ReactReconciler":225,"./Transaction":248,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"object-assign":145}],231:[function(require,module,exports){
+},{"./CallbackQueue":166,"./PooledClass":184,"./ReactFeatureFlags":216,"./ReactReconciler":232,"./Transaction":255,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"object-assign":152}],238:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -17766,7 +17903,7 @@ module.exports = ReactUpdates;
 'use strict';
 
 module.exports = '15.6.2';
-},{}],232:[function(require,module,exports){
+},{}],239:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18066,7 +18203,7 @@ Object.keys(ATTRS).forEach(function (key) {
 });
 
 module.exports = SVGDOMPropertyConfig;
-},{}],233:[function(require,module,exports){
+},{}],240:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18252,7 +18389,7 @@ var SelectEventPlugin = {
 };
 
 module.exports = SelectEventPlugin;
-},{"./EventPropagators":172,"./ReactDOMComponentTree":186,"./ReactInputSelection":213,"./SyntheticEvent":239,"./isTextInputElement":271,"fbjs/lib/ExecutionEnvironment":120,"fbjs/lib/getActiveElement":129,"fbjs/lib/shallowEqual":140}],234:[function(require,module,exports){
+},{"./EventPropagators":179,"./ReactDOMComponentTree":193,"./ReactInputSelection":220,"./SyntheticEvent":246,"./isTextInputElement":278,"fbjs/lib/ExecutionEnvironment":127,"fbjs/lib/getActiveElement":136,"fbjs/lib/shallowEqual":147}],241:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -18478,7 +18615,7 @@ var SimpleEventPlugin = {
 
 module.exports = SimpleEventPlugin;
 }).call(this,require('_process'))
-},{"./EventPropagators":172,"./ReactDOMComponentTree":186,"./SyntheticAnimationEvent":235,"./SyntheticClipboardEvent":236,"./SyntheticDragEvent":238,"./SyntheticEvent":239,"./SyntheticFocusEvent":240,"./SyntheticKeyboardEvent":242,"./SyntheticMouseEvent":243,"./SyntheticTouchEvent":244,"./SyntheticTransitionEvent":245,"./SyntheticUIEvent":246,"./SyntheticWheelEvent":247,"./getEventCharCode":259,"./reactProdInvariant":273,"_process":146,"fbjs/lib/EventListener":119,"fbjs/lib/emptyFunction":126,"fbjs/lib/invariant":134}],235:[function(require,module,exports){
+},{"./EventPropagators":179,"./ReactDOMComponentTree":193,"./SyntheticAnimationEvent":242,"./SyntheticClipboardEvent":243,"./SyntheticDragEvent":245,"./SyntheticEvent":246,"./SyntheticFocusEvent":247,"./SyntheticKeyboardEvent":249,"./SyntheticMouseEvent":250,"./SyntheticTouchEvent":251,"./SyntheticTransitionEvent":252,"./SyntheticUIEvent":253,"./SyntheticWheelEvent":254,"./getEventCharCode":266,"./reactProdInvariant":280,"_process":153,"fbjs/lib/EventListener":126,"fbjs/lib/emptyFunction":133,"fbjs/lib/invariant":141}],242:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18515,7 +18652,7 @@ function SyntheticAnimationEvent(dispatchConfig, dispatchMarker, nativeEvent, na
 SyntheticEvent.augmentClass(SyntheticAnimationEvent, AnimationEventInterface);
 
 module.exports = SyntheticAnimationEvent;
-},{"./SyntheticEvent":239}],236:[function(require,module,exports){
+},{"./SyntheticEvent":246}],243:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18551,7 +18688,7 @@ function SyntheticClipboardEvent(dispatchConfig, dispatchMarker, nativeEvent, na
 SyntheticEvent.augmentClass(SyntheticClipboardEvent, ClipboardEventInterface);
 
 module.exports = SyntheticClipboardEvent;
-},{"./SyntheticEvent":239}],237:[function(require,module,exports){
+},{"./SyntheticEvent":246}],244:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18585,7 +18722,7 @@ function SyntheticCompositionEvent(dispatchConfig, dispatchMarker, nativeEvent, 
 SyntheticEvent.augmentClass(SyntheticCompositionEvent, CompositionEventInterface);
 
 module.exports = SyntheticCompositionEvent;
-},{"./SyntheticEvent":239}],238:[function(require,module,exports){
+},{"./SyntheticEvent":246}],245:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18619,7 +18756,7 @@ function SyntheticDragEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeE
 SyntheticMouseEvent.augmentClass(SyntheticDragEvent, DragEventInterface);
 
 module.exports = SyntheticDragEvent;
-},{"./SyntheticMouseEvent":243}],239:[function(require,module,exports){
+},{"./SyntheticMouseEvent":250}],246:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -18890,7 +19027,7 @@ function getPooledWarningPropertyDefinition(propName, getVal) {
   }
 }
 }).call(this,require('_process'))
-},{"./PooledClass":177,"_process":146,"fbjs/lib/emptyFunction":126,"fbjs/lib/warning":141,"object-assign":145}],240:[function(require,module,exports){
+},{"./PooledClass":184,"_process":153,"fbjs/lib/emptyFunction":133,"fbjs/lib/warning":148,"object-assign":152}],247:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18924,7 +19061,7 @@ function SyntheticFocusEvent(dispatchConfig, dispatchMarker, nativeEvent, native
 SyntheticUIEvent.augmentClass(SyntheticFocusEvent, FocusEventInterface);
 
 module.exports = SyntheticFocusEvent;
-},{"./SyntheticUIEvent":246}],241:[function(require,module,exports){
+},{"./SyntheticUIEvent":253}],248:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -18959,7 +19096,7 @@ function SyntheticInputEvent(dispatchConfig, dispatchMarker, nativeEvent, native
 SyntheticEvent.augmentClass(SyntheticInputEvent, InputEventInterface);
 
 module.exports = SyntheticInputEvent;
-},{"./SyntheticEvent":239}],242:[function(require,module,exports){
+},{"./SyntheticEvent":246}],249:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19041,7 +19178,7 @@ function SyntheticKeyboardEvent(dispatchConfig, dispatchMarker, nativeEvent, nat
 SyntheticUIEvent.augmentClass(SyntheticKeyboardEvent, KeyboardEventInterface);
 
 module.exports = SyntheticKeyboardEvent;
-},{"./SyntheticUIEvent":246,"./getEventCharCode":259,"./getEventKey":260,"./getEventModifierState":261}],243:[function(require,module,exports){
+},{"./SyntheticUIEvent":253,"./getEventCharCode":266,"./getEventKey":267,"./getEventModifierState":268}],250:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19111,7 +19248,7 @@ function SyntheticMouseEvent(dispatchConfig, dispatchMarker, nativeEvent, native
 SyntheticUIEvent.augmentClass(SyntheticMouseEvent, MouseEventInterface);
 
 module.exports = SyntheticMouseEvent;
-},{"./SyntheticUIEvent":246,"./ViewportMetrics":249,"./getEventModifierState":261}],244:[function(require,module,exports){
+},{"./SyntheticUIEvent":253,"./ViewportMetrics":256,"./getEventModifierState":268}],251:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19154,7 +19291,7 @@ function SyntheticTouchEvent(dispatchConfig, dispatchMarker, nativeEvent, native
 SyntheticUIEvent.augmentClass(SyntheticTouchEvent, TouchEventInterface);
 
 module.exports = SyntheticTouchEvent;
-},{"./SyntheticUIEvent":246,"./getEventModifierState":261}],245:[function(require,module,exports){
+},{"./SyntheticUIEvent":253,"./getEventModifierState":268}],252:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19191,7 +19328,7 @@ function SyntheticTransitionEvent(dispatchConfig, dispatchMarker, nativeEvent, n
 SyntheticEvent.augmentClass(SyntheticTransitionEvent, TransitionEventInterface);
 
 module.exports = SyntheticTransitionEvent;
-},{"./SyntheticEvent":239}],246:[function(require,module,exports){
+},{"./SyntheticEvent":246}],253:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19248,7 +19385,7 @@ function SyntheticUIEvent(dispatchConfig, dispatchMarker, nativeEvent, nativeEve
 SyntheticEvent.augmentClass(SyntheticUIEvent, UIEventInterface);
 
 module.exports = SyntheticUIEvent;
-},{"./SyntheticEvent":239,"./getEventTarget":262}],247:[function(require,module,exports){
+},{"./SyntheticEvent":246,"./getEventTarget":269}],254:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19297,7 +19434,7 @@ function SyntheticWheelEvent(dispatchConfig, dispatchMarker, nativeEvent, native
 SyntheticMouseEvent.augmentClass(SyntheticWheelEvent, WheelEventInterface);
 
 module.exports = SyntheticWheelEvent;
-},{"./SyntheticMouseEvent":243}],248:[function(require,module,exports){
+},{"./SyntheticMouseEvent":250}],255:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -19525,7 +19662,7 @@ var TransactionImpl = {
 
 module.exports = TransactionImpl;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],249:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],256:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19548,7 +19685,7 @@ var ViewportMetrics = {
 };
 
 module.exports = ViewportMetrics;
-},{}],250:[function(require,module,exports){
+},{}],257:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -19606,7 +19743,7 @@ function accumulateInto(current, next) {
 
 module.exports = accumulateInto;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134}],251:[function(require,module,exports){
+},{"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141}],258:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19648,7 +19785,7 @@ function adler32(data) {
 }
 
 module.exports = adler32;
-},{}],252:[function(require,module,exports){
+},{}],259:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -19735,7 +19872,7 @@ function checkReactTypeSpec(typeSpecs, values, location, componentName, element,
 
 module.exports = checkReactTypeSpec;
 }).call(this,require('_process'))
-},{"./ReactPropTypeLocationNames":222,"./ReactPropTypesSecret":223,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],253:[function(require,module,exports){
+},{"./ReactPropTypeLocationNames":229,"./ReactPropTypesSecret":230,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],260:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -19765,7 +19902,7 @@ var createMicrosoftUnsafeLocalFunction = function (func) {
 };
 
 module.exports = createMicrosoftUnsafeLocalFunction;
-},{}],254:[function(require,module,exports){
+},{}],261:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -19844,7 +19981,7 @@ function dangerousStyleValue(name, value, component, isCustomProperty) {
 
 module.exports = dangerousStyleValue;
 }).call(this,require('_process'))
-},{"./CSSProperty":157,"_process":146,"fbjs/lib/warning":141}],255:[function(require,module,exports){
+},{"./CSSProperty":164,"_process":153,"fbjs/lib/warning":148}],262:[function(require,module,exports){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
  *
@@ -19964,7 +20101,7 @@ function escapeTextContentForBrowser(text) {
 }
 
 module.exports = escapeTextContentForBrowser;
-},{}],256:[function(require,module,exports){
+},{}],263:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -20024,7 +20161,7 @@ function findDOMNode(componentOrElement) {
 
 module.exports = findDOMNode;
 }).call(this,require('_process'))
-},{"./ReactDOMComponentTree":186,"./ReactInstanceMap":214,"./getHostComponentFromComposite":263,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"react/lib/ReactCurrentOwner":286}],257:[function(require,module,exports){
+},{"./ReactDOMComponentTree":193,"./ReactInstanceMap":221,"./getHostComponentFromComposite":270,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"react/lib/ReactCurrentOwner":293}],264:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -20100,7 +20237,7 @@ function flattenChildren(children, selfDebugID) {
 
 module.exports = flattenChildren;
 }).call(this,require('_process'))
-},{"./KeyEscapeUtils":175,"./traverseAllChildren":278,"_process":146,"fbjs/lib/warning":141,"react/lib/ReactComponentTreeHook":285}],258:[function(require,module,exports){
+},{"./KeyEscapeUtils":182,"./traverseAllChildren":285,"_process":153,"fbjs/lib/warning":148,"react/lib/ReactComponentTreeHook":292}],265:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20129,7 +20266,7 @@ function forEachAccumulated(arr, cb, scope) {
 }
 
 module.exports = forEachAccumulated;
-},{}],259:[function(require,module,exports){
+},{}],266:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20177,7 +20314,7 @@ function getEventCharCode(nativeEvent) {
 }
 
 module.exports = getEventCharCode;
-},{}],260:[function(require,module,exports){
+},{}],267:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20287,7 +20424,7 @@ function getEventKey(nativeEvent) {
 }
 
 module.exports = getEventKey;
-},{"./getEventCharCode":259}],261:[function(require,module,exports){
+},{"./getEventCharCode":266}],268:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20328,7 +20465,7 @@ function getEventModifierState(nativeEvent) {
 }
 
 module.exports = getEventModifierState;
-},{}],262:[function(require,module,exports){
+},{}],269:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20361,7 +20498,7 @@ function getEventTarget(nativeEvent) {
 }
 
 module.exports = getEventTarget;
-},{}],263:[function(require,module,exports){
+},{}],270:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20389,7 +20526,7 @@ function getHostComponentFromComposite(inst) {
 }
 
 module.exports = getHostComponentFromComposite;
-},{"./ReactNodeTypes":220}],264:[function(require,module,exports){
+},{"./ReactNodeTypes":227}],271:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20428,7 +20565,7 @@ function getIteratorFn(maybeIterable) {
 }
 
 module.exports = getIteratorFn;
-},{}],265:[function(require,module,exports){
+},{}],272:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20500,7 +20637,7 @@ function getNodeForCharacterOffset(root, offset) {
 }
 
 module.exports = getNodeForCharacterOffset;
-},{}],266:[function(require,module,exports){
+},{}],273:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20531,7 +20668,7 @@ function getTextContentAccessor() {
 }
 
 module.exports = getTextContentAccessor;
-},{"fbjs/lib/ExecutionEnvironment":120}],267:[function(require,module,exports){
+},{"fbjs/lib/ExecutionEnvironment":127}],274:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20630,7 +20767,7 @@ function getVendorPrefixedEventName(eventName) {
 }
 
 module.exports = getVendorPrefixedEventName;
-},{"fbjs/lib/ExecutionEnvironment":120}],268:[function(require,module,exports){
+},{"fbjs/lib/ExecutionEnvironment":127}],275:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20751,7 +20888,7 @@ var inputValueTracking = {
 };
 
 module.exports = inputValueTracking;
-},{"./ReactDOMComponentTree":186}],269:[function(require,module,exports){
+},{"./ReactDOMComponentTree":193}],276:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -20880,7 +21017,7 @@ _assign(ReactCompositeComponentWrapper.prototype, ReactCompositeComponent, {
 
 module.exports = instantiateReactComponent;
 }).call(this,require('_process'))
-},{"./ReactCompositeComponent":182,"./ReactEmptyComponent":205,"./ReactHostComponent":210,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"object-assign":145,"react/lib/getNextDebugID":300}],270:[function(require,module,exports){
+},{"./ReactCompositeComponent":189,"./ReactEmptyComponent":212,"./ReactHostComponent":217,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"object-assign":152,"react/lib/getNextDebugID":307}],277:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20938,7 +21075,7 @@ function isEventSupported(eventNameSuffix, capture) {
 }
 
 module.exports = isEventSupported;
-},{"fbjs/lib/ExecutionEnvironment":120}],271:[function(require,module,exports){
+},{"fbjs/lib/ExecutionEnvironment":127}],278:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -20987,7 +21124,7 @@ function isTextInputElement(elem) {
 }
 
 module.exports = isTextInputElement;
-},{}],272:[function(require,module,exports){
+},{}],279:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21011,7 +21148,7 @@ function quoteAttributeValueForBrowser(value) {
 }
 
 module.exports = quoteAttributeValueForBrowser;
-},{"./escapeTextContentForBrowser":255}],273:[function(require,module,exports){
+},{"./escapeTextContentForBrowser":262}],280:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21048,7 +21185,7 @@ function reactProdInvariant(code) {
 }
 
 module.exports = reactProdInvariant;
-},{}],274:[function(require,module,exports){
+},{}],281:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21062,7 +21199,7 @@ module.exports = reactProdInvariant;
 var ReactMount = require('./ReactMount');
 
 module.exports = ReactMount.renderSubtreeIntoContainer;
-},{"./ReactMount":218}],275:[function(require,module,exports){
+},{"./ReactMount":225}],282:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21158,7 +21295,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 module.exports = setInnerHTML;
-},{"./DOMNamespaces":163,"./createMicrosoftUnsafeLocalFunction":253,"fbjs/lib/ExecutionEnvironment":120}],276:[function(require,module,exports){
+},{"./DOMNamespaces":170,"./createMicrosoftUnsafeLocalFunction":260,"fbjs/lib/ExecutionEnvironment":127}],283:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21208,7 +21345,7 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 module.exports = setTextContent;
-},{"./escapeTextContentForBrowser":255,"./setInnerHTML":275,"fbjs/lib/ExecutionEnvironment":120}],277:[function(require,module,exports){
+},{"./escapeTextContentForBrowser":262,"./setInnerHTML":282,"fbjs/lib/ExecutionEnvironment":127}],284:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -21248,7 +21385,7 @@ function shouldUpdateReactComponent(prevElement, nextElement) {
 }
 
 module.exports = shouldUpdateReactComponent;
-},{}],278:[function(require,module,exports){
+},{}],285:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -21424,7 +21561,7 @@ function traverseAllChildren(children, callback, traverseContext) {
 
 module.exports = traverseAllChildren;
 }).call(this,require('_process'))
-},{"./KeyEscapeUtils":175,"./ReactElementSymbol":204,"./getIteratorFn":264,"./reactProdInvariant":273,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141,"react/lib/ReactCurrentOwner":286}],279:[function(require,module,exports){
+},{"./KeyEscapeUtils":182,"./ReactElementSymbol":211,"./getIteratorFn":271,"./reactProdInvariant":280,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148,"react/lib/ReactCurrentOwner":293}],286:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -21795,11 +21932,11 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = validateDOMNesting;
 }).call(this,require('_process'))
-},{"_process":146,"fbjs/lib/emptyFunction":126,"fbjs/lib/warning":141,"object-assign":145}],280:[function(require,module,exports){
-arguments[4][175][0].apply(exports,arguments)
-},{"dup":175}],281:[function(require,module,exports){
-arguments[4][177][0].apply(exports,arguments)
-},{"./reactProdInvariant":303,"_process":146,"dup":177,"fbjs/lib/invariant":134}],282:[function(require,module,exports){
+},{"_process":153,"fbjs/lib/emptyFunction":133,"fbjs/lib/warning":148,"object-assign":152}],287:[function(require,module,exports){
+arguments[4][182][0].apply(exports,arguments)
+},{"dup":182}],288:[function(require,module,exports){
+arguments[4][184][0].apply(exports,arguments)
+},{"./reactProdInvariant":310,"_process":153,"dup":184,"fbjs/lib/invariant":141}],289:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -21931,7 +22068,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = React;
 }).call(this,require('_process'))
-},{"./ReactBaseClasses":283,"./ReactChildren":284,"./ReactDOMFactories":287,"./ReactElement":288,"./ReactElementValidator":290,"./ReactPropTypes":293,"./ReactVersion":295,"./canDefineProperty":296,"./createClass":298,"./lowPriorityWarning":301,"./onlyChild":302,"_process":146,"object-assign":145}],283:[function(require,module,exports){
+},{"./ReactBaseClasses":290,"./ReactChildren":291,"./ReactDOMFactories":294,"./ReactElement":295,"./ReactElementValidator":297,"./ReactPropTypes":300,"./ReactVersion":302,"./canDefineProperty":303,"./createClass":305,"./lowPriorityWarning":308,"./onlyChild":309,"_process":153,"object-assign":152}],290:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -22074,7 +22211,7 @@ module.exports = {
   PureComponent: ReactPureComponent
 };
 }).call(this,require('_process'))
-},{"./ReactNoopUpdateQueue":291,"./canDefineProperty":296,"./lowPriorityWarning":301,"./reactProdInvariant":303,"_process":146,"fbjs/lib/emptyObject":127,"fbjs/lib/invariant":134,"object-assign":145}],284:[function(require,module,exports){
+},{"./ReactNoopUpdateQueue":298,"./canDefineProperty":303,"./lowPriorityWarning":308,"./reactProdInvariant":310,"_process":153,"fbjs/lib/emptyObject":134,"fbjs/lib/invariant":141,"object-assign":152}],291:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -22263,7 +22400,7 @@ var ReactChildren = {
 };
 
 module.exports = ReactChildren;
-},{"./PooledClass":281,"./ReactElement":288,"./traverseAllChildren":304,"fbjs/lib/emptyFunction":126}],285:[function(require,module,exports){
+},{"./PooledClass":288,"./ReactElement":295,"./traverseAllChildren":311,"fbjs/lib/emptyFunction":133}],292:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2016-present, Facebook, Inc.
@@ -22642,7 +22779,7 @@ var ReactComponentTreeHook = {
 
 module.exports = ReactComponentTreeHook;
 }).call(this,require('_process'))
-},{"./ReactCurrentOwner":286,"./reactProdInvariant":303,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141}],286:[function(require,module,exports){
+},{"./ReactCurrentOwner":293,"./reactProdInvariant":310,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148}],293:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -22669,7 +22806,7 @@ var ReactCurrentOwner = {
 };
 
 module.exports = ReactCurrentOwner;
-},{}],287:[function(require,module,exports){
+},{}],294:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -22838,7 +22975,7 @@ var ReactDOMFactories = {
 
 module.exports = ReactDOMFactories;
 }).call(this,require('_process'))
-},{"./ReactElement":288,"./ReactElementValidator":290,"_process":146}],288:[function(require,module,exports){
+},{"./ReactElement":295,"./ReactElementValidator":297,"_process":153}],295:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -23179,9 +23316,9 @@ ReactElement.isValidElement = function (object) {
 
 module.exports = ReactElement;
 }).call(this,require('_process'))
-},{"./ReactCurrentOwner":286,"./ReactElementSymbol":289,"./canDefineProperty":296,"_process":146,"fbjs/lib/warning":141,"object-assign":145}],289:[function(require,module,exports){
-arguments[4][204][0].apply(exports,arguments)
-},{"dup":204}],290:[function(require,module,exports){
+},{"./ReactCurrentOwner":293,"./ReactElementSymbol":296,"./canDefineProperty":303,"_process":153,"fbjs/lib/warning":148,"object-assign":152}],296:[function(require,module,exports){
+arguments[4][211][0].apply(exports,arguments)
+},{"dup":211}],297:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -23436,7 +23573,7 @@ var ReactElementValidator = {
 
 module.exports = ReactElementValidator;
 }).call(this,require('_process'))
-},{"./ReactComponentTreeHook":285,"./ReactCurrentOwner":286,"./ReactElement":288,"./canDefineProperty":296,"./checkReactTypeSpec":297,"./getIteratorFn":299,"./lowPriorityWarning":301,"_process":146,"fbjs/lib/warning":141}],291:[function(require,module,exports){
+},{"./ReactComponentTreeHook":292,"./ReactCurrentOwner":293,"./ReactElement":295,"./canDefineProperty":303,"./checkReactTypeSpec":304,"./getIteratorFn":306,"./lowPriorityWarning":308,"_process":153,"fbjs/lib/warning":148}],298:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -23531,9 +23668,9 @@ var ReactNoopUpdateQueue = {
 
 module.exports = ReactNoopUpdateQueue;
 }).call(this,require('_process'))
-},{"_process":146,"fbjs/lib/warning":141}],292:[function(require,module,exports){
-arguments[4][222][0].apply(exports,arguments)
-},{"_process":146,"dup":222}],293:[function(require,module,exports){
+},{"_process":153,"fbjs/lib/warning":148}],299:[function(require,module,exports){
+arguments[4][229][0].apply(exports,arguments)
+},{"_process":153,"dup":229}],300:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -23550,11 +23687,11 @@ var _require = require('./ReactElement'),
 var factory = require('prop-types/factory');
 
 module.exports = factory(isValidElement);
-},{"./ReactElement":288,"prop-types/factory":148}],294:[function(require,module,exports){
-arguments[4][223][0].apply(exports,arguments)
-},{"dup":223}],295:[function(require,module,exports){
-arguments[4][231][0].apply(exports,arguments)
-},{"dup":231}],296:[function(require,module,exports){
+},{"./ReactElement":295,"prop-types/factory":155}],301:[function(require,module,exports){
+arguments[4][230][0].apply(exports,arguments)
+},{"dup":230}],302:[function(require,module,exports){
+arguments[4][238][0].apply(exports,arguments)
+},{"dup":238}],303:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -23580,7 +23717,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = canDefineProperty;
 }).call(this,require('_process'))
-},{"_process":146}],297:[function(require,module,exports){
+},{"_process":153}],304:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -23667,7 +23804,7 @@ function checkReactTypeSpec(typeSpecs, values, location, componentName, element,
 
 module.exports = checkReactTypeSpec;
 }).call(this,require('_process'))
-},{"./ReactComponentTreeHook":285,"./ReactPropTypeLocationNames":292,"./ReactPropTypesSecret":294,"./reactProdInvariant":303,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141}],298:[function(require,module,exports){
+},{"./ReactComponentTreeHook":292,"./ReactPropTypeLocationNames":299,"./ReactPropTypesSecret":301,"./reactProdInvariant":310,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148}],305:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -23688,9 +23825,9 @@ var ReactNoopUpdateQueue = require('./ReactNoopUpdateQueue');
 var factory = require('create-react-class/factory');
 
 module.exports = factory(Component, isValidElement, ReactNoopUpdateQueue);
-},{"./ReactBaseClasses":283,"./ReactElement":288,"./ReactNoopUpdateQueue":291,"create-react-class/factory":117}],299:[function(require,module,exports){
-arguments[4][264][0].apply(exports,arguments)
-},{"dup":264}],300:[function(require,module,exports){
+},{"./ReactBaseClasses":290,"./ReactElement":295,"./ReactNoopUpdateQueue":298,"create-react-class/factory":124}],306:[function(require,module,exports){
+arguments[4][271][0].apply(exports,arguments)
+},{"dup":271}],307:[function(require,module,exports){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  *
@@ -23709,7 +23846,7 @@ function getNextDebugID() {
 }
 
 module.exports = getNextDebugID;
-},{}],301:[function(require,module,exports){
+},{}],308:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2014-present, Facebook, Inc.
@@ -23774,7 +23911,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 module.exports = lowPriorityWarning;
 }).call(this,require('_process'))
-},{"_process":146}],302:[function(require,module,exports){
+},{"_process":153}],309:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -23812,9 +23949,9 @@ function onlyChild(children) {
 
 module.exports = onlyChild;
 }).call(this,require('_process'))
-},{"./ReactElement":288,"./reactProdInvariant":303,"_process":146,"fbjs/lib/invariant":134}],303:[function(require,module,exports){
-arguments[4][273][0].apply(exports,arguments)
-},{"dup":273}],304:[function(require,module,exports){
+},{"./ReactElement":295,"./reactProdInvariant":310,"_process":153,"fbjs/lib/invariant":141}],310:[function(require,module,exports){
+arguments[4][280][0].apply(exports,arguments)
+},{"dup":280}],311:[function(require,module,exports){
 (function (process){
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -23990,10 +24127,10 @@ function traverseAllChildren(children, callback, traverseContext) {
 
 module.exports = traverseAllChildren;
 }).call(this,require('_process'))
-},{"./KeyEscapeUtils":280,"./ReactCurrentOwner":286,"./ReactElementSymbol":289,"./getIteratorFn":299,"./reactProdInvariant":303,"_process":146,"fbjs/lib/invariant":134,"fbjs/lib/warning":141}],305:[function(require,module,exports){
+},{"./KeyEscapeUtils":287,"./ReactCurrentOwner":293,"./ReactElementSymbol":296,"./getIteratorFn":306,"./reactProdInvariant":310,"_process":153,"fbjs/lib/invariant":141,"fbjs/lib/warning":148}],312:[function(require,module,exports){
 'use strict';
 
 module.exports = require('./lib/React');
 
-},{"./lib/React":282}]},{},[1])(1)
+},{"./lib/React":289}]},{},[1])(1)
 });

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -229,6 +229,31 @@ var Demo = function (_React$Component) {
           _react2.default.createElement(
             'h2',
             null,
+            'Sizes in different units'
+          ),
+          _react2.default.createElement(
+            'div',
+            null,
+            _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '30pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '90pt', round: true, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '170pt', textSizeRatio: 4 })
+          ),
+          _react2.default.createElement(
+            'div',
+            null,
+            _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '4vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '6vw', round: true, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '15vw', textSizeRatio: 4 })
+          )
+        ),
+        _react2.default.createElement(
+          'section',
+          null,
+          _react2.default.createElement(
+            'h2',
+            null,
             'Initials with maximum number of characters'
           ),
           _react2.default.createElement(

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,17 +197,17 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsImage',
         value: function _renderAsImage() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var round = this.props.round;
             var alt = this.props.name || this.props.value;
             var imageStyle = this.props.unstyled ? null : {
                 maxWidth: '100%',
-                width: size,
-                height: size,
+                width: size.str,
+                height: size.str,
                 borderRadius: round ? 500 : 0
             };
-            return _react2.default.createElement('img', { width: this.props.size,
-                height: this.props.size,
+            return _react2.default.createElement('img', { width: size.str,
+                height: size.str,
                 style: imageStyle,
                 src: this.state.src,
                 alt: alt,
@@ -216,14 +216,14 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsText',
         value: function _renderAsText() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var textSizeRatio = this.props.textSizeRatio;
             var round = this.props.round;
             var initialsStyle = this.props.unstyled ? null : {
-                width: size,
-                height: size,
-                font: Math.floor(size / textSizeRatio) + 'px Helvetica, Arial, sans-serif',
-                lineHeight: size + 'px', // yes, px suffix is needed on lineHeight
+                width: size.str,
+                height: size.str,
+                font: (size.value / textSizeRatio).toFixed(4) + size.unit + ' Helvetica, Arial, sans-serif',
+                lineHeight: size.str, // yes, px suffix is needed on lineHeight
                 textAlign: 'center',
                 textTransform: 'uppercase',
                 color: this.props.fgColor,
@@ -239,11 +239,11 @@ var Avatar = function (_PureComponent) {
     }, {
         key: 'render',
         value: function render() {
-            var size = this.props.size;
+            var size = (0, _utils.parseSize)(this.props.size);
             var hostStyle = this.props.unstyled ? null : (0, _extends3.default)({
                 display: 'inline-block',
-                width: size,
-                height: size,
+                width: size.str,
+                height: size.str,
                 borderRadius: this.props.round ? 500 : 0
             }, this.props.style);
             return _react2.default.createElement(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,10 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
+var _slicedToArray2 = require('babel-runtime/helpers/slicedToArray');
+
+var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
+
 var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
 var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
@@ -11,6 +15,7 @@ var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
 exports.fetch = fetch;
 exports.fetchJSONP = fetchJSONP;
 exports.getRandomColor = getRandomColor;
+exports.parseSize = parseSize;
 exports.cacheFailingSource = cacheFailingSource;
 exports.hasSourceFailedBefore = hasSourceFailedBefore;
 
@@ -52,6 +57,9 @@ function fetchJSONP(url, successCb, errorCb) {
 
 var defaultColors = ['#d73d32', '#7e3794', '#4285f4', '#67ae3f', '#d61a7f', '#ff4080'];
 
+// https://regex101.com/r/YEsPER/1
+var reSize = /^([-+]?(?:\d+(?:\.\d+)?|\.\d+))([a-z]{2,4})?$/;
+
 function _stringAsciiCodeSum(value) {
     return [].concat((0, _toConsumableArray3.default)(value)).map(function (letter) {
         return letter.charCodeAt(0);
@@ -76,6 +84,23 @@ function getRandomColor(value) {
     var sum = _stringAsciiCodeSum(value);
     var colorIndex = sum % colors.length;
     return colors[colorIndex];
+}
+
+function parseSize(size) {
+    size = '' + size;
+
+    var _ref = reSize.exec(size) || [],
+        _ref2 = (0, _slicedToArray3.default)(_ref, 3),
+        _ref2$ = _ref2[1],
+        value = _ref2$ === undefined ? 0 : _ref2$,
+        _ref2$2 = _ref2[2],
+        unit = _ref2$2 === undefined ? 'px' : _ref2$2;
+
+    return {
+        value: parseFloat(value),
+        str: value + unit,
+        unit: unit
+    };
 }
 
 function isLocalStorageAvailable() {

--- a/src/demo.js
+++ b/src/demo.js
@@ -116,6 +116,22 @@ class Demo extends React.Component {
       </section>
 
       <section>
+        <h2>Size in different units</h2>
+        <div>
+          <Avatar name={this.state.name} skypeId={this.state.skypeId} size="30pt" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="90pt" round={true} textSizeRatio={4} />
+          <Avatar name={this.state.name} size="130pt" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="170pt" textSizeRatio={4} />
+        </div>
+        <div>
+          <Avatar name={this.state.name} skypeId={this.state.skypeId} size="4vw" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="6vw" round={true} textSizeRatio={4} />
+          <Avatar name={this.state.name} size="10vw" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="15vw" textSizeRatio={4} />
+        </div>
+      </section>
+
+      <section>
         <h2>Initials with maximum number of characters</h2>
         <div>
           <Avatar name={this.state.name} maxInitials={2} skypeId={this.state.skypeId} size={40} textSizeRatio={2} />

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import {cacheFailingSource, hasSourceFailedBefore} from './utils.js';
+import {cacheFailingSource, hasSourceFailedBefore, parseSize} from './utils.js';
 
 import gravatarSource from './sources/Gravatar.js';
 import facebookSource from './sources/Facebook.js';
@@ -194,18 +194,18 @@ export default class Avatar extends PureComponent {
     };
 
     _renderAsImage() {
-        const size = this.props.size;
+        const size = parseSize(this.props.size);
         const round = this.props.round;
         const alt = this.props.name || this.props.value;
         const imageStyle = this.props.unstyled ? null : {
             maxWidth: '100%',
-            width: size,
-            height: size,
+            width: size.str,
+            height: size.str,
             borderRadius: (round ? 500 : 0)
         };
         return (
-            <img width={this.props.size}
-                height={this.props.size}
+            <img width={size.str}
+                height={size.str}
                 style={imageStyle}
                 src={this.state.src}
                 alt={alt}
@@ -214,14 +214,14 @@ export default class Avatar extends PureComponent {
     }
 
     _renderAsText() {
-        const size = this.props.size;
+        const size = parseSize(this.props.size);
         const textSizeRatio = this.props.textSizeRatio;
         const round = this.props.round;
         const initialsStyle = this.props.unstyled ? null : {
-            width: size,
-            height: size,
-            font: Math.floor(size / textSizeRatio) + 'px Helvetica, Arial, sans-serif',
-            lineHeight: size + 'px', // yes, px suffix is needed on lineHeight
+            width: size.str,
+            height: size.str,
+            font: (size.value / textSizeRatio).toFixed(4) + size.unit + ' Helvetica, Arial, sans-serif',
+            lineHeight: size.str,
             textAlign: 'center',
             textTransform: 'uppercase',
             color: this.props.fgColor,
@@ -236,11 +236,11 @@ export default class Avatar extends PureComponent {
     }
 
     render() {
-        const size = this.props.size;
+        const size = parseSize(this.props.size);
         const hostStyle = this.props.unstyled ? null : {
             display: 'inline-block',
-            width: size,
-            height: size,
+            width: size.str,
+            height: size.str,
             borderRadius: (this.props.round ? 500 : 0),
             ...this.props.style
         };

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,6 +45,10 @@ const defaultColors = [
     '#ff4080'
 ];
 
+// https://regex101.com/r/YEsPER/1
+// https://developer.mozilla.org/en-US/docs/Web/CSS/length
+const reSize = /^([-+]?(?:\d+(?:\.\d+)?|\.\d+))([a-z]{2,4})?$/;
+
 function _stringAsciiCodeSum(value) {
     return [...value]
         .map(letter => letter.charCodeAt(0))
@@ -68,6 +72,22 @@ function getRandomColor(value, colors = defaultColors)
     const sum = _stringAsciiCodeSum(value);
     const colorIndex = (sum % colors.length);
     return colors[colorIndex];
+}
+
+export
+function parseSize(size) {
+    size = '' + size;
+
+    const [,
+        value = 0,
+        unit = 'px'
+    ] = reSize.exec(size) || [];
+
+    return {
+        value: parseFloat(value),
+        str: value + unit,
+        unit
+    };
 }
 
 function isLocalStorageAvailable() {


### PR DESCRIPTION
Allow the unit in which the size should be measured to be supplied as
part of the `size` value.

Replaces https://github.com/Sitebase/react-avatar/pull/82
Resolves https://github.com/Sitebase/react-avatar/issues/57