### PR TITLE
[round] allow custom radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Some examples:
 | `fgColor`     | *string*          | #FFF  | Used in combination with `name` and `value`. Give the text a fixed color with a hex like for example #FF0000 |
 | `size`        | *[length][1]*             | 50px      | Size of the avatar                                                                                     |
 | `textSizeRatio` | *number*             | 3      | For text based avatars the size of the text as a fragment of size (size / textSizeRatio)                                 |
-| `round`       | *bool*            | false   | Round the avatar corners                                                                               |
+| `round`       | *bool or [length][1]*            | false   | The amount of `border-radius` to apply to the avatar corners, `true` shows the avatar in a circle.          |
 | `src`         | *string*          |         | Fallback image to use                                                                                  |
 | `style`         | *object*          |         | Style that will be applied on the root element                                                       |
 | `unstyled`    | *bool*            | false   | Disable all styles                                                                                     |

--- a/build/demo.js
+++ b/build/demo.js
@@ -84,7 +84,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { className: 'myCustomClass', md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 40 }),
           _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 150 }),
+          _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 200 })
         ),
         _react2.default.createElement(
@@ -107,7 +107,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 40 }),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 150 }),
+          _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 200 })
         ),
         _react2.default.createElement(
@@ -120,7 +120,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 40 }),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 150 }),
+          _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 200 })
         ),
         _react2.default.createElement(
@@ -133,7 +133,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 40 }),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 150 }),
+          _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 200 })
         ),
         _react2.default.createElement(
@@ -146,7 +146,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 40 }),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 150 }),
+          _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 200 })
         ),
         _react2.default.createElement(
@@ -159,7 +159,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 40 }),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 150 }),
+          _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 200 })
         ),
         _react2.default.createElement(
@@ -186,7 +186,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40 }),
           _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { name: this.state.name, size: 150 }),
+          _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { name: this.state.name, size: 200 })
         ),
         _react2.default.createElement(
@@ -212,7 +212,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40, textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true, textSizeRatio: 2 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 2 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 2 })
           ),
           _react2.default.createElement(
@@ -220,7 +220,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40, textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 4 })
           )
         ),
@@ -237,7 +237,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '30pt', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '90pt', round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '170pt', textSizeRatio: 4 })
           ),
           _react2.default.createElement(
@@ -245,7 +245,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '4vw', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '6vw', round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '15vw', textSizeRatio: 4 })
           )
         ),
@@ -262,7 +262,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, maxInitials: 2, skypeId: this.state.skypeId, size: 40, textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, maxInitials: 1, size: 100, round: true, textSizeRatio: 2 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 2 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 2 })
           )
         ),
@@ -276,7 +276,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { value: '86%', size: 40 }),
           _react2.default.createElement(_index2.default, { value: '86%', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { value: '86%', size: 150 }),
+          _react2.default.createElement(_index2.default, { value: '86%', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { value: '86%', size: 200 })
         ),
         _react2.default.createElement(
@@ -558,16 +558,24 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsImage',
         value: function _renderAsImage() {
+            var _props = this.props,
+                className = _props.className,
+                round = _props.round,
+                unstyled = _props.unstyled,
+                name = _props.name,
+                value = _props.value;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var round = this.props.round;
-            var alt = this.props.name || this.props.value;
-            var imageStyle = this.props.unstyled ? null : {
+            var alt = name || value;
+
+            var imageStyle = unstyled ? null : {
                 maxWidth: '100%',
                 width: size.str,
                 height: size.str,
-                borderRadius: round ? 500 : 0
+                borderRadius: round === true ? '100%' : round
             };
-            return _react2.default.createElement('img', { className: this.props.className + ' sb-avatar__image',
+
+            return _react2.default.createElement('img', { className: className + ' sb-avatar__image',
                 width: size.str,
                 height: size.str,
                 style: imageStyle,
@@ -578,10 +586,15 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsText',
         value: function _renderAsText() {
+            var _props2 = this.props,
+                className = _props2.className,
+                textSizeRatio = _props2.textSizeRatio,
+                round = _props2.round,
+                unstyled = _props2.unstyled;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var textSizeRatio = this.props.textSizeRatio;
-            var round = this.props.round;
-            var initialsStyle = this.props.unstyled ? null : {
+
+            var initialsStyle = unstyled ? null : {
                 width: size.str,
                 height: size.str,
                 fontSize: (size.value / textSizeRatio).toFixed(4) + size.unit,
@@ -590,11 +603,12 @@ var Avatar = function (_PureComponent) {
                 textTransform: 'uppercase',
                 color: this.props.fgColor,
                 background: this.state.color,
-                borderRadius: round ? '100%' : 0
+                borderRadius: round === true ? '100%' : round
             };
+
             return _react2.default.createElement(
                 'div',
-                { className: this.props.className + ' sb-avatar__text',
+                { className: className + ' sb-avatar__text',
                     style: initialsStyle },
                 this.state.value
             );
@@ -602,19 +616,28 @@ var Avatar = function (_PureComponent) {
     }, {
         key: 'render',
         value: function render() {
+            var _props3 = this.props,
+                className = _props3.className,
+                unstyled = _props3.unstyled,
+                round = _props3.round,
+                style = _props3.style,
+                onClick = _props3.onClick;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var hostStyle = this.props.unstyled ? null : (0, _extends3.default)({
+
+            var hostStyle = unstyled ? null : (0, _extends3.default)({
                 display: 'inline-block',
                 verticalAlign: 'middle',
                 width: size.str,
                 height: size.str,
-                borderRadius: this.props.round ? 500 : 0,
+                borderRadius: round === true ? '100%' : round,
                 fontFamily: 'Helvetica, Arial, sans-serif'
-            }, this.props.style);
+            }, style);
+
             return _react2.default.createElement(
                 'div',
-                { className: this.props.className + 'sb-avatar',
-                    onClick: this.props.onClick,
+                { className: className + 'sb-avatar',
+                    onClick: onClick,
                     style: hostStyle },
                 this.state.src ? this._renderAsImage() : this._renderAsText()
             );
@@ -640,7 +663,7 @@ Avatar.propTypes = {
     twitterHandle: _propTypes2.default.string,
     vkontakteId: _propTypes2.default.string,
     skypeId: _propTypes2.default.string,
-    round: _propTypes2.default.bool,
+    round: _propTypes2.default.oneOfType([_propTypes2.default.bool, _propTypes2.default.string]),
     style: _propTypes2.default.object,
     size: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string]),
     textSizeRatio: _propTypes2.default.number,

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -83,7 +83,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { className: 'myCustomClass', md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 40 }),
           _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 150 }),
+          _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { md5Email: '8c5d4c4b9ef6c68c4ff91c319d4c56be', size: 200 })
         ),
         _react2.default.createElement(
@@ -106,7 +106,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 40 }),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 150 }),
+          _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { googleId: '116933859726289749306', size: 200 })
         ),
         _react2.default.createElement(
@@ -119,7 +119,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 40 }),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 150 }),
+          _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { facebookId: '100008343750912', size: 200 })
         ),
         _react2.default.createElement(
@@ -132,7 +132,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 40 }),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 150 }),
+          _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { twitterHandle: 'sitebase', size: 200 })
         ),
         _react2.default.createElement(
@@ -145,7 +145,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 40 }),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 150 }),
+          _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { vkontakteId: '1', size: 200 })
         ),
         _react2.default.createElement(
@@ -158,7 +158,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 40 }),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 150 }),
+          _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { skypeId: 'sitebase', size: 200 })
         ),
         _react2.default.createElement(
@@ -185,7 +185,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40 }),
           _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { name: this.state.name, size: 150 }),
+          _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { name: this.state.name, size: 200 })
         ),
         _react2.default.createElement(
@@ -211,7 +211,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40, textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true, textSizeRatio: 2 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 2 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 2 })
           ),
           _react2.default.createElement(
@@ -219,7 +219,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: 40, textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 100, round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 4 })
           )
         ),
@@ -236,7 +236,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '30pt', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '90pt', round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '130pt', round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '170pt', textSizeRatio: 4 })
           ),
           _react2.default.createElement(
@@ -244,7 +244,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, skypeId: this.state.skypeId, size: '4vw', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '6vw', round: true, textSizeRatio: 4 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', textSizeRatio: 4 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: '10vw', round: '20px', textSizeRatio: 4 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: '15vw', textSizeRatio: 4 })
           )
         ),
@@ -261,7 +261,7 @@ var Demo = function (_React$Component) {
             null,
             _react2.default.createElement(_index2.default, { name: this.state.name, maxInitials: 2, skypeId: this.state.skypeId, size: 40, textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, maxInitials: 1, size: 100, round: true, textSizeRatio: 2 }),
-            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, textSizeRatio: 2 }),
+            _react2.default.createElement(_index2.default, { name: this.state.name, size: 150, round: '20px', textSizeRatio: 2 }),
             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200, textSizeRatio: 2 })
           )
         ),
@@ -275,7 +275,7 @@ var Demo = function (_React$Component) {
           ),
           _react2.default.createElement(_index2.default, { value: '86%', size: 40 }),
           _react2.default.createElement(_index2.default, { value: '86%', size: 100, round: true }),
-          _react2.default.createElement(_index2.default, { value: '86%', size: 150 }),
+          _react2.default.createElement(_index2.default, { value: '86%', size: 150, round: '20px' }),
           _react2.default.createElement(_index2.default, { value: '86%', size: 200 })
         ),
         _react2.default.createElement(

--- a/lib/index.js
+++ b/lib/index.js
@@ -198,16 +198,24 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsImage',
         value: function _renderAsImage() {
+            var _props = this.props,
+                className = _props.className,
+                round = _props.round,
+                unstyled = _props.unstyled,
+                name = _props.name,
+                value = _props.value;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var round = this.props.round;
-            var alt = this.props.name || this.props.value;
-            var imageStyle = this.props.unstyled ? null : {
+            var alt = name || value;
+
+            var imageStyle = unstyled ? null : {
                 maxWidth: '100%',
                 width: size.str,
                 height: size.str,
-                borderRadius: round ? 500 : 0
+                borderRadius: round === true ? '100%' : round
             };
-            return _react2.default.createElement('img', { className: this.props.className + ' sb-avatar__image',
+
+            return _react2.default.createElement('img', { className: className + ' sb-avatar__image',
                 width: size.str,
                 height: size.str,
                 style: imageStyle,
@@ -218,10 +226,15 @@ var Avatar = function (_PureComponent) {
     }, {
         key: '_renderAsText',
         value: function _renderAsText() {
+            var _props2 = this.props,
+                className = _props2.className,
+                textSizeRatio = _props2.textSizeRatio,
+                round = _props2.round,
+                unstyled = _props2.unstyled;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var textSizeRatio = this.props.textSizeRatio;
-            var round = this.props.round;
-            var initialsStyle = this.props.unstyled ? null : {
+
+            var initialsStyle = unstyled ? null : {
                 width: size.str,
                 height: size.str,
                 fontSize: (size.value / textSizeRatio).toFixed(4) + size.unit,
@@ -230,11 +243,12 @@ var Avatar = function (_PureComponent) {
                 textTransform: 'uppercase',
                 color: this.props.fgColor,
                 background: this.state.color,
-                borderRadius: round ? '100%' : 0
+                borderRadius: round === true ? '100%' : round
             };
+
             return _react2.default.createElement(
                 'div',
-                { className: this.props.className + ' sb-avatar__text',
+                { className: className + ' sb-avatar__text',
                     style: initialsStyle },
                 this.state.value
             );
@@ -242,19 +256,28 @@ var Avatar = function (_PureComponent) {
     }, {
         key: 'render',
         value: function render() {
+            var _props3 = this.props,
+                className = _props3.className,
+                unstyled = _props3.unstyled,
+                round = _props3.round,
+                style = _props3.style,
+                onClick = _props3.onClick;
+
             var size = (0, _utils.parseSize)(this.props.size);
-            var hostStyle = this.props.unstyled ? null : (0, _extends3.default)({
+
+            var hostStyle = unstyled ? null : (0, _extends3.default)({
                 display: 'inline-block',
                 verticalAlign: 'middle',
                 width: size.str,
                 height: size.str,
-                borderRadius: this.props.round ? 500 : 0,
+                borderRadius: round === true ? '100%' : round,
                 fontFamily: 'Helvetica, Arial, sans-serif'
-            }, this.props.style);
+            }, style);
+
             return _react2.default.createElement(
                 'div',
-                { className: this.props.className + 'sb-avatar',
-                    onClick: this.props.onClick,
+                { className: className + 'sb-avatar',
+                    onClick: onClick,
                     style: hostStyle },
                 this.state.src ? this._renderAsImage() : this._renderAsText()
             );
@@ -280,7 +303,7 @@ Avatar.propTypes = {
     twitterHandle: _propTypes2.default.string,
     vkontakteId: _propTypes2.default.string,
     skypeId: _propTypes2.default.string,
-    round: _propTypes2.default.bool,
+    round: _propTypes2.default.oneOfType([_propTypes2.default.bool, _propTypes2.default.string]),
     style: _propTypes2.default.object,
     size: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.string]),
     textSizeRatio: _propTypes2.default.number,

--- a/src/demo.js
+++ b/src/demo.js
@@ -33,7 +33,7 @@ class Demo extends React.Component {
         <h2>Gravatar</h2>
         <Avatar className="myCustomClass" md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={40} />
         <Avatar md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={100} round={true} />
-        <Avatar md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={150} />
+        <Avatar md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={150} round="20px" />
         <Avatar md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={200} />
       </section>
 
@@ -46,7 +46,7 @@ class Demo extends React.Component {
         <h2>Google+</h2>
         <Avatar googleId="116933859726289749306" size={40} />
         <Avatar googleId="116933859726289749306" size={100} round={true} />
-        <Avatar googleId="116933859726289749306" size={150} />
+        <Avatar googleId="116933859726289749306" size={150} round="20px" />
         <Avatar googleId="116933859726289749306" size={200} />
       </section>
 
@@ -54,7 +54,7 @@ class Demo extends React.Component {
         <h2>Facebook</h2>
         <Avatar facebookId="100008343750912" size={40} />
         <Avatar facebookId="100008343750912" size={100} round={true} />
-        <Avatar facebookId="100008343750912" size={150} />
+        <Avatar facebookId="100008343750912" size={150} round="20px" />
         <Avatar facebookId="100008343750912" size={200} />
       </section>
 
@@ -62,7 +62,7 @@ class Demo extends React.Component {
         <h2>Twitter</h2>
         <Avatar twitterHandle="sitebase" size={40} />
         <Avatar twitterHandle="sitebase" size={100} round={true} />
-        <Avatar twitterHandle="sitebase" size={150} />
+        <Avatar twitterHandle="sitebase" size={150} round="20px" />
         <Avatar twitterHandle="sitebase" size={200} />
       </section>
 
@@ -70,7 +70,7 @@ class Demo extends React.Component {
         <h2>Vkontakte</h2>
         <Avatar vkontakteId="1" size={40} />
         <Avatar vkontakteId="1" size={100} round={true} />
-        <Avatar vkontakteId="1" size={150} />
+        <Avatar vkontakteId="1" size={150} round="20px" />
         <Avatar vkontakteId="1" size={200} />
       </section>
 
@@ -78,7 +78,7 @@ class Demo extends React.Component {
         <h2>Skype</h2>
         <Avatar skypeId="sitebase" size={40} />
         <Avatar skypeId="sitebase" size={100} round={true} />
-        <Avatar skypeId="sitebase" size={150} />
+        <Avatar skypeId="sitebase" size={150} round="20px" />
         <Avatar skypeId="sitebase" size={200} />
       </section>
 
@@ -90,7 +90,7 @@ class Demo extends React.Component {
         </div>
         <Avatar name={this.state.name} skypeId={this.state.skypeId} size={40} />
         <Avatar name={this.state.name} size={100} round={true}/>
-        <Avatar name={this.state.name} size={150} />
+        <Avatar name={this.state.name} size={150} round="20px" />
         <Avatar name={this.state.name} size={200} />
       </section>
 
@@ -104,13 +104,13 @@ class Demo extends React.Component {
         <div>
           <Avatar name={this.state.name} skypeId={this.state.skypeId} size={40} textSizeRatio={2} />
           <Avatar name={this.state.name} size={100} round={true} textSizeRatio={2} />
-          <Avatar name={this.state.name} size={150} textSizeRatio={2} />
+          <Avatar name={this.state.name} size={150} round="20px" textSizeRatio={2} />
           <Avatar name={this.state.name} size={200} textSizeRatio={2} />
         </div>
         <div>
           <Avatar name={this.state.name} skypeId={this.state.skypeId} size={40} textSizeRatio={4} />
           <Avatar name={this.state.name} size={100} round={true} textSizeRatio={4} />
-          <Avatar name={this.state.name} size={150} textSizeRatio={4} />
+          <Avatar name={this.state.name} size={150} round="20px" textSizeRatio={4} />
           <Avatar name={this.state.name} size={200} textSizeRatio={4} />
         </div>
       </section>
@@ -120,13 +120,13 @@ class Demo extends React.Component {
         <div>
           <Avatar name={this.state.name} skypeId={this.state.skypeId} size="30pt" textSizeRatio={4} />
           <Avatar name={this.state.name} size="90pt" round={true} textSizeRatio={4} />
-          <Avatar name={this.state.name} size="130pt" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="130pt" round="20px" textSizeRatio={4} />
           <Avatar name={this.state.name} size="170pt" textSizeRatio={4} />
         </div>
         <div>
           <Avatar name={this.state.name} skypeId={this.state.skypeId} size="4vw" textSizeRatio={4} />
           <Avatar name={this.state.name} size="6vw" round={true} textSizeRatio={4} />
-          <Avatar name={this.state.name} size="10vw" textSizeRatio={4} />
+          <Avatar name={this.state.name} size="10vw" round="20px" textSizeRatio={4} />
           <Avatar name={this.state.name} size="15vw" textSizeRatio={4} />
         </div>
       </section>
@@ -136,7 +136,7 @@ class Demo extends React.Component {
         <div>
           <Avatar name={this.state.name} maxInitials={2} skypeId={this.state.skypeId} size={40} textSizeRatio={2} />
           <Avatar name={this.state.name} maxInitials={1} size={100} round={true} textSizeRatio={2} />
-          <Avatar name={this.state.name} size={150} textSizeRatio={2} />
+          <Avatar name={this.state.name} size={150} round="20px" textSizeRatio={2} />
           <Avatar name={this.state.name} size={200} textSizeRatio={2} />
         </div>
       </section>
@@ -145,7 +145,7 @@ class Demo extends React.Component {
         <h2>Value</h2>
         <Avatar value="86%" size={40} />
         <Avatar value="86%" size={100} round={true} />
-        <Avatar value="86%" size={150} />
+        <Avatar value="86%" size={150} round="20px" />
         <Avatar value="86%" size={200} />
       </section>
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,10 @@ export default class Avatar extends PureComponent {
         twitterHandle: PropTypes.string,
         vkontakteId: PropTypes.string,
         skypeId: PropTypes.string,
-        round: PropTypes.bool,
+        round: PropTypes.oneOfType([
+            PropTypes.bool,
+            PropTypes.string
+        ]),
         style: PropTypes.object,
         size: PropTypes.oneOfType([
             PropTypes.number,
@@ -198,17 +201,19 @@ export default class Avatar extends PureComponent {
     };
 
     _renderAsImage() {
+        const { className, round, unstyled, name, value } = this.props;
         const size = parseSize(this.props.size);
-        const round = this.props.round;
-        const alt = this.props.name || this.props.value;
-        const imageStyle = this.props.unstyled ? null : {
+        const alt = name || value;
+
+        const imageStyle = unstyled ? null : {
             maxWidth: '100%',
             width: size.str,
             height: size.str,
-            borderRadius: (round ? 500 : 0)
+            borderRadius: (round === true ? '100%' : round)
         };
+
         return (
-            <img className={this.props.className + ' sb-avatar__image'}
+            <img className={className + ' sb-avatar__image'}
                 width={size.str}
                 height={size.str}
                 style={imageStyle}
@@ -219,10 +224,10 @@ export default class Avatar extends PureComponent {
     }
 
     _renderAsText() {
+        const { className, textSizeRatio, round, unstyled } = this.props;
         const size = parseSize(this.props.size);
-        const textSizeRatio = this.props.textSizeRatio;
-        const round = this.props.round;
-        const initialsStyle = this.props.unstyled ? null : {
+
+        const initialsStyle = unstyled ? null : {
             width: size.str,
             height: size.str,
             fontSize: (size.value / textSizeRatio).toFixed(4) + size.unit,
@@ -231,10 +236,11 @@ export default class Avatar extends PureComponent {
             textTransform: 'uppercase',
             color: this.props.fgColor,
             background: this.state.color,
-            borderRadius: (round ? '100%' : 0)
+            borderRadius: (round === true ? '100%' : round)
         };
+
         return (
-            <div className={this.props.className + ' sb-avatar__text'}
+            <div className={className + ' sb-avatar__text'}
                 style={initialsStyle}>
                 {this.state.value}
             </div>
@@ -242,19 +248,22 @@ export default class Avatar extends PureComponent {
     }
 
     render() {
+        const { className, unstyled, round, style, onClick } = this.props;
         const size = parseSize(this.props.size);
-        const hostStyle = this.props.unstyled ? null : {
+
+        const hostStyle = unstyled ? null : {
             display: 'inline-block',
             verticalAlign: 'middle',
             width: size.str,
             height: size.str,
-            borderRadius: (this.props.round ? 500 : 0),
+            borderRadius: (round === true ? '100%' : round),
             fontFamily: 'Helvetica, Arial, sans-serif',
-            ...this.props.style
+            ...style
         };
+
         return (
-            <div className={this.props.className + 'sb-avatar'}
-                onClick={this.props.onClick}
+            <div className={className + 'sb-avatar'}
+                onClick={onClick}
                 style={hostStyle}>
                 {this.state.src ? this._renderAsImage() : this._renderAsText()}
             </div>


### PR DESCRIPTION
Extend the existing `round` property to allow for a custom borderRadius
on the avatar. When set to `false` now allows for CSS that manipulates avatar rounding.

Replaces https://github.com/Sitebase/react-avatar/pull/83