### PR TITLE
export ConfigProvider as component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,4 +113,5 @@ export interface Cache {
  */
 declare const ReactAvatar: React.ComponentType<ReactAvatarProps>;
 
+export const ConfigProvider: React.ComponentType<ConfigProvider>;
 export default ReactAvatar;


### PR DESCRIPTION
I was unable to import ConfigProvider and use it as an element in my code.
Getting "[ts] 'ConfigProvider' only refers to a type, but is being used as a value here."