### PR TITLE
[initials] Add support for custom initial methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ import Avatar, { ConfigProvider } from 'react-avatar';
 | `skypeId`    | *string*          |         |                                                                                                        |
 | `name`        | *string*          |         | Will be used to generate avatar based on the initials of the person                                    |
 | `maxInitials` | *number*          |         | Set max nr of characters used for the initials. If maxInitials=2 and the name is Foo Bar Var the initials will be FB  |
+| `initials` | *string or function* | [defaultInitials][3] | Set the initials to show or a function that derives them from the component props, the method should have the signature `fn(name, props)` |
 | `value`       | *string*          |         | Show a value as avatar                                                                                 |
 | `color`       | *string*          | random  | Used in combination with `name` and `value`. Give the background a fixed color with a hex like for example #FF0000 |
 | `fgColor`     | *string*          | #FFF  | Used in combination with `name` and `value`. Give the text a fixed color with a hex like for example #FF0000 |
@@ -125,6 +126,7 @@ import Avatar, { ConfigProvider } from 'react-avatar';
 | ------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `colors`       | *array(string)*  | [default colors](https://github.com/Sitebase/react-avatar/tree/master/src/utils.js#L39-L47)  | A list of color values as strings from which the `getRandomColor` picks one at random. |
 | `cache`       | *[cache](#implementing-a-custom-cache)*          | [internal cache](https://github.com/Sitebase/react-avatar/tree/master/src/cache.js)  | Cache implementation used to track broken img URLs |
+| `initials` | *function* | [defaultInitials][3] | A function that derives the initials from the component props, the method should have the signature `fn(name, props)`  |
 | `avatarRedirectUrl`  | *URL*          | `undefined`  | Base URL to a [Avatar Redirect](#avatar-redirect) instance |
 
 
@@ -201,3 +203,4 @@ For detailed changelog, check [Releases](https://github.com/sitebase/react-avata
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/length
 [2]: https://github.com/JorgenEvens/avatar-redirect
+[3]: https://github.com/Sitebase/react-avatar/blob/master/src/utils.js

--- a/build/demo.js
+++ b/build/demo.js
@@ -117,6 +117,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var defaults = {
     cache: _cache2.default,
     colors: _utils.defaultColors,
+    initials: _utils.defaultInitials,
     avatarRedirectUrl: null
 };
 
@@ -207,6 +208,7 @@ ConfigProvider.displayName = 'ConfigProvider';
 ConfigProvider.propTypes = {
     cache: _propTypes2.default.object,
     colors: _propTypes2.default.arrayOf(_propTypes2.default.string),
+    initials: _propTypes2.default.func,
     avatarRedirectUrl: _propTypes2.default.string,
 
     children: _propTypes2.default.node
@@ -708,6 +710,29 @@ var Demo = function (_React$Component) {
                             'h2',
                             null,
                             'Configuration Context'
+                        ),
+                        _react2.default.createElement(
+                            'div',
+                            null,
+                            _react2.default.createElement(_index2.default, { name: 'Jim Jones', size: 40 }),
+                            _react2.default.createElement(_index2.default, { name: 'Jamie Jones', size: 100, round: true }),
+                            _react2.default.createElement(_index2.default, { name: 'JJ', size: 150, round: '20px' }),
+                            _react2.default.createElement(_index2.default, { name: this.state.name, size: 200 })
+                        )
+                    )
+                ),
+                _react2.default.createElement(
+                    _index.ConfigProvider,
+                    { initials: function initials(name) {
+                            return name.split(/\s+/)[0];
+                        } },
+                    _react2.default.createElement(
+                        'section',
+                        null,
+                        _react2.default.createElement(
+                            'h2',
+                            null,
+                            'Custom Initials Function'
                         ),
                         _react2.default.createElement(
                             'div',
@@ -1656,14 +1681,16 @@ var ValueSource = function () {
     (0, _createClass3.default)(ValueSource, [{
         key: 'getInitials',
         value: function getInitials() {
-            var name = this.props.name;
-            var maxInitials = this.props.maxInitials;
-            var parts = name.split(' ');
-            var initials = '';
-            for (var i = 0; i < parts.length; i++) {
-                initials += parts[i].substr(0, 1).toUpperCase();
-            }
-            return maxInitials ? initials.slice(0, maxInitials) : initials;
+            var _props = this.props,
+                name = _props.name,
+                initials = _props.initials;
+
+
+            if (typeof initials === 'string') return initials;
+
+            if (typeof initials === 'function') return initials(name, this.props);
+
+            return (0, _utils.defaultInitials)(name, this.props);
         }
     }, {
         key: 'getValue',
@@ -1677,12 +1704,12 @@ var ValueSource = function () {
     }, {
         key: 'getColor',
         value: function getColor() {
-            var _props = this.props,
-                color = _props.color,
-                colors = _props.colors,
-                name = _props.name,
-                email = _props.email,
-                value = _props.value;
+            var _props2 = this.props,
+                color = _props2.color,
+                colors = _props2.colors,
+                name = _props2.name,
+                email = _props2.email,
+                value = _props2.value;
 
             var colorValue = name || email || value;
             return color || (0, _utils.getRandomColor)(colorValue, colors);
@@ -1696,7 +1723,8 @@ ValueSource.propTypes = {
     name: _propTypes2.default.string,
     value: _propTypes2.default.string,
     email: _propTypes2.default.string,
-    maxInitials: _propTypes2.default.number
+    maxInitials: _propTypes2.default.number,
+    initials: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func])
 };
 exports.default = ValueSource;
 module.exports = exports['default'];
@@ -1801,6 +1829,7 @@ exports.fetch = fetch;
 exports.fetchJSONP = fetchJSONP;
 exports.getRandomColor = getRandomColor;
 exports.parseSize = parseSize;
+exports.defaultInitials = defaultInitials;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -1899,6 +1928,16 @@ function parseSize(size) {
         str: value + unit,
         unit: unit
     };
+}
+
+function defaultInitials(name, _ref3) {
+    var maxInitials = _ref3.maxInitials;
+
+    return name.split(/\s/).map(function (part) {
+        return part.substring(0, 1).toUpperCase();
+    }).filter(function (v) {
+        return !!v;
+    }).slice(0, maxInitials).join('');
 }
 },{"babel-runtime/helpers/slicedToArray":35,"babel-runtime/helpers/toConsumableArray":36}],17:[function(require,module,exports){
 module.exports = { "default": require("core-js/library/fn/array/from"), __esModule: true };

--- a/lib/context.js
+++ b/lib/context.js
@@ -52,6 +52,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var defaults = {
     cache: _cache2.default,
     colors: _utils.defaultColors,
+    initials: _utils.defaultInitials,
     avatarRedirectUrl: null
 };
 
@@ -142,6 +143,7 @@ ConfigProvider.displayName = 'ConfigProvider';
 ConfigProvider.propTypes = {
     cache: _propTypes2.default.object,
     colors: _propTypes2.default.arrayOf(_propTypes2.default.string),
+    initials: _propTypes2.default.func,
     avatarRedirectUrl: _propTypes2.default.string,
 
     children: _propTypes2.default.node

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -501,6 +501,29 @@ var Demo = function (_React$Component) {
                             _react2.default.createElement(_index2.default, { name: this.state.name, size: 200 })
                         )
                     )
+                ),
+                _react2.default.createElement(
+                    _index.ConfigProvider,
+                    { initials: function initials(name) {
+                            return name.split(/\s+/)[0];
+                        } },
+                    _react2.default.createElement(
+                        'section',
+                        null,
+                        _react2.default.createElement(
+                            'h2',
+                            null,
+                            'Custom Initials Function'
+                        ),
+                        _react2.default.createElement(
+                            'div',
+                            null,
+                            _react2.default.createElement(_index2.default, { name: 'Jim Jones', size: 40 }),
+                            _react2.default.createElement(_index2.default, { name: 'Jamie Jones', size: 100, round: true }),
+                            _react2.default.createElement(_index2.default, { name: 'JJ', size: 150, round: '20px' }),
+                            _react2.default.createElement(_index2.default, { name: this.state.name, size: 200 })
+                        )
+                    )
                 )
             );
         }

--- a/lib/sources/Value.js
+++ b/lib/sources/Value.js
@@ -49,14 +49,16 @@ var ValueSource = function () {
     (0, _createClass3.default)(ValueSource, [{
         key: 'getInitials',
         value: function getInitials() {
-            var name = this.props.name;
-            var maxInitials = this.props.maxInitials;
-            var parts = name.split(' ');
-            var initials = '';
-            for (var i = 0; i < parts.length; i++) {
-                initials += parts[i].substr(0, 1).toUpperCase();
-            }
-            return maxInitials ? initials.slice(0, maxInitials) : initials;
+            var _props = this.props,
+                name = _props.name,
+                initials = _props.initials;
+
+
+            if (typeof initials === 'string') return initials;
+
+            if (typeof initials === 'function') return initials(name, this.props);
+
+            return (0, _utils.defaultInitials)(name, this.props);
         }
     }, {
         key: 'getValue',
@@ -70,12 +72,12 @@ var ValueSource = function () {
     }, {
         key: 'getColor',
         value: function getColor() {
-            var _props = this.props,
-                color = _props.color,
-                colors = _props.colors,
-                name = _props.name,
-                email = _props.email,
-                value = _props.value;
+            var _props2 = this.props,
+                color = _props2.color,
+                colors = _props2.colors,
+                name = _props2.name,
+                email = _props2.email,
+                value = _props2.value;
 
             var colorValue = name || email || value;
             return color || (0, _utils.getRandomColor)(colorValue, colors);
@@ -89,7 +91,8 @@ ValueSource.propTypes = {
     name: _propTypes2.default.string,
     value: _propTypes2.default.string,
     email: _propTypes2.default.string,
-    maxInitials: _propTypes2.default.number
+    maxInitials: _propTypes2.default.number,
+    initials: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func])
 };
 exports.default = ValueSource;
 module.exports = exports['default'];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,7 @@ exports.fetch = fetch;
 exports.fetchJSONP = fetchJSONP;
 exports.getRandomColor = getRandomColor;
 exports.parseSize = parseSize;
+exports.defaultInitials = defaultInitials;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -115,4 +116,14 @@ function parseSize(size) {
         str: value + unit,
         unit: unit
     };
+}
+
+function defaultInitials(name, _ref3) {
+    var maxInitials = _ref3.maxInitials;
+
+    return name.split(/\s/).map(function (part) {
+        return part.substring(0, 1).toUpperCase();
+    }).filter(function (v) {
+        return !!v;
+    }).slice(0, maxInitials).join('');
 }

--- a/src/context.js
+++ b/src/context.js
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import defaultCache from './cache';
-import {defaultColors} from './utils';
+import {defaultColors, defaultInitials} from './utils';
 
 const defaults = {
     cache: defaultCache,
     colors: defaultColors,
+    initials: defaultInitials,
     avatarRedirectUrl: null
 };
 
@@ -52,6 +53,7 @@ export class ConfigProvider extends React.Component {
     static propTypes = {
         cache: PropTypes.object,
         colors: PropTypes.arrayOf(PropTypes.string),
+        initials: PropTypes.func,
         avatarRedirectUrl: PropTypes.string,
 
         children: PropTypes.node

--- a/src/demo.js
+++ b/src/demo.js
@@ -298,6 +298,18 @@ class Demo extends React.Component {
                     </section>
                 </ConfigProvider>
 
+                <ConfigProvider initials={name => name.split(/\s+/)[0]}>
+                    <section>
+                        <h2>Custom Initials Function</h2>
+                        <div>
+                            <Avatar name="Jim Jones" size={40} />
+                            <Avatar name="Jamie Jones" size={100} round={true} />
+                            <Avatar name="JJ" size={150} round="20px" />
+                            <Avatar name={this.state.name} size={200} />
+                        </div>
+                    </section>
+                </ConfigProvider>
+
             </div>
         );
     }

--- a/src/sources/Value.js
+++ b/src/sources/Value.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import PropTypes from 'prop-types';
-import {getRandomColor} from '../utils';
+import {getRandomColor, defaultInitials} from '../utils';
 
 export default
 class ValueSource {
@@ -11,7 +11,11 @@ class ValueSource {
         name: PropTypes.string,
         value: PropTypes.string,
         email: PropTypes.string,
-        maxInitials: PropTypes.number
+        maxInitials: PropTypes.number,
+        initials: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.func
+        ])
     }
 
     props = null
@@ -25,15 +29,15 @@ class ValueSource {
     }
 
     getInitials() {
-        const name = this.props.name;
-        const maxInitials = this.props.maxInitials;
-        const parts = name.split(' ');
-        let initials = '';
-        for(let i = 0 ; i < parts.length ; i++)
-        {
-            initials += parts[i].substr(0, 1).toUpperCase();
-        }
-        return maxInitials ? initials.slice(0, maxInitials) : initials;
+        const { name, initials } = this.props;
+
+        if (typeof initials === 'string')
+            return initials;
+
+        if (typeof initials === 'function')
+            return initials(name, this.props);
+
+        return defaultInitials(name, this.props);
     }
 
     getValue() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,3 +103,12 @@ function parseSize(size) {
         unit
     };
 }
+
+export
+function defaultInitials(name, { maxInitials }) {
+    return name.split(/\s/)
+        .map(part => part.substring(0, 1).toUpperCase())
+        .filter(v => !!v)
+        .slice(0, maxInitials)
+        .join('');
+}


### PR DESCRIPTION
This PR adds the `initials` property to the `ConfigProvider` and to `Avatar` which can be used to set a custom method for generating the initials shown by `react-avatar`.

**usage**

```js
function customInitials(name) {
    return name.split(' ')
        .map(part => part.substring(0, 1).toUpperCase())
        .filter(v => /[A-Z]/.test(v))
        .join('');
}

<ConfigProvider initials={customInitials}>
    <Avatar name="Hello World" />
    <Avatar name="Test User" />
</ConfigProvider>

<Avatar name="Hello World" initials={customInitials} />
<Avatar name="Hello World" initials="HFW" />
```

Resolves https://github.com/Sitebase/react-avatar/issues/81