### PR TITLE
[src] Initials source was skipped sometimes.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ class Avatar extends PureComponent {
 
         this.state = {
             internal: null,
-            src: props.src,
+            src: null,
             value: null,
             color: props.color
         };


### PR DESCRIPTION
Src was added to state when the component loaded, this caused the
"next" (internal.fetch) handler to be called multiple times on error. Because of
this the initials source was skipped most times.