### PR TITLE
improve font-size consistency with textMarginRatio property

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ import Avatar, { ConfigProvider } from 'react-avatar';
 | `fgColor`     | *string*          | #FFF  | Used in combination with `name` and `value`. Give the text a fixed color with a hex like for example #FF0000 |
 | `size`        | *[length][1]*             | 50px      | Size of the avatar                                                                                     |
 | `textSizeRatio` | *number*             | 3      | For text based avatars the size of the text as a fragment of size (size / textSizeRatio)                                 |
+| `textMarginRatio` | *number*             | .15      | For text based avatars. The size of the minimum margin between the text and the avatar's edge, used to make sure the text will always fit inside the avatar. (calculated as `size * textMarginRatio`)                                 |
 | `round`       | *bool or [length][1]*            | false   | The amount of `border-radius` to apply to the avatar corners, `true` shows the avatar in a circle.          |
 | `src`         | *string*          |         | Fallback image to use                                                                                  |
 | `style`         | *object*          |         | Style that will be applied on the root element                                                       |

--- a/demo/index.js
+++ b/demo/index.js
@@ -218,6 +218,42 @@ class Demo extends React.Component {
                 </section>
 
                 <section>
+                    <h2>Initials are always restrained to a margin</h2>
+                    <div>
+                        <Avatar name="A B C B W X Y Z" size={40} textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size={100} round={true} textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size={150} round="20px" textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size={200} textSizeRatio={1} />
+                    </div>
+                    <div>
+                        <Avatar name="A B C B W X Y Z" size="30pt" textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size="90pt" round={true} textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size="130pt" round="20px" textSizeRatio={1} />
+                        <Avatar name="A B C B W X Y Z" size="170pt" textSizeRatio={1} />
+                    </div>
+                    <div>
+                        <Avatar value="A B C B W X Y Z" size="4vw" textSizeRatio={1} />
+                        <Avatar value="A B C B W X Y Z" size="6vw" round={true} textSizeRatio={1} />
+                        <Avatar value="A B C B W X Y Z" size="10vw" round="20px" textSizeRatio={1} />
+                        <Avatar value="A B C B W X Y Z" size="15vw" textSizeRatio={1} />
+                    </div>
+                    <div style={{ overflow: 'hidden', margin: '0 auto', width: '800px', textAlign: 'center' }}>
+                        <div style={{ width: '200px', height: '200px', float: 'left' }}>
+                            <Avatar value="A B C B W X Y Z" skypeId={this.state.skypeId} size="30%" />
+                        </div>
+                        <div style={{ width: '200px', height: '200px', float: 'left' }}>
+                            <Avatar value="A B C B W X Y Z" size="45%" round={true} />
+                        </div>
+                        <div style={{ width: '200px', height: '200px', float: 'left' }}>
+                            <Avatar value="A B C B W X Y Z" size="60%" round="20px" />
+                        </div>
+                        <div style={{ width: '200px', height: '200px', float: 'left' }}>
+                            <Avatar value="A B C B W X Y Z" size="100%" />
+                        </div>
+                    </div>
+                </section>
+
+                <section>
                     <h2>Custom colors</h2>
                     <div>
                         <Avatar name={this.state.name} color={getRandomColor('Jim Jones', customColors)} size={40} />

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,10 @@ export interface ReactAvatarProps {
      */
     textSizeRatio?: number;
     /**
+     * For text based avatars. The size of the minimum margin between the text and the avatar's edge, used to make sure the text will always fit inside the avatar. (calculated as `size * textMarginRatio`)
+     */
+    textMarginRatio?: number;
+    /**
      * The amount of `border-radius` to apply to the avatar corners, `true` shows the avatar in a circle.
      */
     round?: boolean | string;

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ class Avatar extends PureComponent {
             PropTypes.string
         ]),
         textSizeRatio: PropTypes.number,
+        textMarginRatio: PropTypes.number,
         unstyled: PropTypes.bool,
         cache: PropTypes.object,
         onClick: PropTypes.func
@@ -93,6 +94,7 @@ class Avatar extends PureComponent {
         round: false,
         size: 100,
         textSizeRatio: 3,
+        textMarginRatio: .15,
         unstyled: false
     }
 
@@ -183,26 +185,37 @@ class Avatar extends PureComponent {
     };
 
     _scaleTextNode = (node) => {
-        const { unstyled, textSizeRatio } = this.props;
+        const { unstyled, textSizeRatio, textMarginRatio } = this.props;
 
-        if (!node || unstyled) return;
+        if (!node || unstyled)
+            return;
 
+        const spanNode = node.parentNode;
+        const tableNode = spanNode.parentNode;
+        const {
+            width: containerWidth,
+            height: containerHeight
+        } = spanNode.getBoundingClientRect();
 
-        const parent = node.parentNode;
+        // If the tableNode (outer-container) does not have its fontSize set yet,
+        // we'll set it according to "textSizeRatio"
+        if (!tableNode.style.fontSize) {
+            const baseFontSize = containerHeight / textSizeRatio;
+            tableNode.style.fontSize = `${baseFontSize}px`;
+        }
 
-        // Reset font-size such that scaling works correctly (#133)
-        parent.style.fontSize = null;
+        // Measure the actual width of the text after setting the container size
+        const { width: textWidth } = node.getBoundingClientRect();
 
-        const textWidth = node.getBoundingClientRect().width;
         if (textWidth < 0)
             return;
 
-        const containerWidth = parent.getBoundingClientRect().width;
-        const ratio = containerWidth / textWidth;
+        // Calculate the maximum width for the text based on "textMarginRatio"
+        const maxTextWidth = containerWidth * (1 - (2 * textMarginRatio));
 
-        // Set font-size on parent span, otherwise the `table-cell` span
-        // will cause alignment issues.
-        parent.style.fontSize = `calc((100% * ${ratio}) / ${textSizeRatio})`;
+        // If the text is too wide, scale it down by (maxWidth / actualWidth)
+        if (textWidth > maxTextWidth)
+            spanNode.style.fontSize = `calc(100% * ${maxTextWidth / textWidth})`;
     }
 
     _renderAsImage() {
@@ -246,13 +259,16 @@ class Avatar extends PureComponent {
 
         const tableStyle = unstyled ? null : {
             display: 'table',
+            tableLayout: 'fixed',
             width: '100%',
             height: '100%'
         };
 
         const spanStyle = unstyled ? null : {
             display: 'table-cell',
-            verticalAlign: 'middle'
+            verticalAlign: 'middle',
+            fontSize: '100%',
+            whiteSpace: 'nowrap'
         };
 
         return (


### PR DESCRIPTION
This is a proposal of a new way to manage font-size on text-based avatars.

The current implementation makes the **width of the text** match `avatarSize / textSizeRatio` but this results in a lot of different font sizes. This happens because when you're not using a monospaced font, "JJ" for example will be significantly narrowed than "WW". This causes font-sizes to very even between avatars that all have two initials. (see image)

![image](https://user-images.githubusercontent.com/1267900/45944899-1593e080-bfec-11e8-85a8-8b56e7023eba.png)

My proposal returns it back to the old implementation where **font-size** is set as `avatarWidth / textSizeRatio`. The problem with that implementation was that avatars with three of four initials could overflow the avatar's background. I propose to solve this by adding a new property `textMarginRatio` which reduces font-size only when the text would become to wide.

For now this is a POC; let me know what you think and I'll dot all the i's 😉 

