### PR TITLE
[compat] Disable transpilation of node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack-dev-server": "^3.1.8"
   },
   "dependencies": {
-    "babel-runtime": ">=5.0.0",
+    "core-js": "^2.5.7",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = {
             use: 'eslint-loader'
         }, {
             test: /\.js$/,
+            exclude: /node_modules/,
             use: 'babel-loader'
         }, {
             test: /\.(css|html|jpe?g|png)$/,


### PR DESCRIPTION
This was causing issues as soon as we allowed babel to transform
builtins. This would cause import statements to appear next to
`module.exports` and trip up webpack when building the ES6 version.