### PR TITLE
#147: improve the get cache function to handle errors

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -25,6 +25,10 @@ export default {
         }
     },
     get(key) {
+        // cache not available
+        if (!_hasLocalStorage)
+            return null;
+            
         const value = localStorage.getItem(CACHE_PREFIX + key);
 
         if (value)


### PR DESCRIPTION
The 'get' function in cache doesn't check if localStorage exists and is accessible first.

Return null if _hasLocalStorage is false.