### PR TITLE
Add support for URI strings that map to Source Types

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -79,6 +79,26 @@ class Demo extends React.Component {
                     </label>
                 </section>
                 <section>
+                    <h2>By URI</h2>
+                    <div style={{display: 'flex', flexFlow: 'row wrap', justifyContent: 'center'}}>
+                        <div>
+                            <h3>Github</h3>
+                            <Avatar className="myCustomClass" uri="github://patricksimonian?size=100" />
+                        </div>
+                        <div>
+                            <h3>Instagram</h3>
+                    <ConfigProvider avatarRedirectUrl="https://avatar-redirect.appspot.com">
+                            <Avatar className="myCustomClass" uri="instagram://sitebase?size=100" />
+                    </ConfigProvider>
+                        </div>
+                        <div>
+                            <h3>Facebook</h3>
+                            <Avatar className="myCustomClass" uri="facebook://100008343750912?size=100" />
+                        </div>
+
+                    </div>
+                </section>
+                <section>
                     <h2>Gravatar</h2>
                     <Avatar className="myCustomClass" md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={40} />
                     <Avatar md5Email="8c5d4c4b9ef6c68c4ff91c319d4c56be" size={100} round={true} />
@@ -158,7 +178,7 @@ class Demo extends React.Component {
 
                 <section>
                     <h2>Github</h2>
-                    <Avatar githubHandle="sitebase" size={40} />
+                    <Avatar githubHandle="patricksimonian" size={40} />
                     <Avatar githubHandle="sitebase" size={100} round={true} />
                     <Avatar githubHandle="sitebase" size={150} round="20px" />
                     <Avatar githubHandle="sitebase" size={200} />

--- a/demo/index.js
+++ b/demo/index.js
@@ -178,7 +178,7 @@ class Demo extends React.Component {
 
                 <section>
                     <h2>Github</h2>
-                    <Avatar githubHandle="patricksimonian" size={40} />
+                    <Avatar githubHandle="sitebase" size={40} />
                     <Avatar githubHandle="sitebase" size={100} round={true} />
                     <Avatar githubHandle="sitebase" size={150} round="20px" />
                     <Avatar githubHandle="sitebase" size={200} />

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
   "dependencies": {
     "core-js": "^2.5.7",
     "is-retina": "^1.0.3",
-    "md5": "^2.0.0"
+    "md5": "^2.0.0",
+    "uri-parser": "^1.0.1",
+    "warning": "^4.0.2"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,9 @@ export const SOURCE_TYPES = {
     ICON: 'ICON',
     SKYPE: 'SKYPE',
     TWITTER: 'TWITTER',
-    SRC: 'SRC'
+    SRC: 'SRC',
+    INSTAGRAM: 'INSTAGRAM',
+    VKONTAKTE: 'VKONTAKTE'
 };
 
 // maps the unified source attribute to the appropriate value that is used by each source
@@ -19,5 +21,7 @@ export const SOURCE_TYPE_SRC_MAPPING = {
     [SOURCE_TYPES.GRAVATAR]: 'email',
     [SOURCE_TYPES.SKYPE]: 'skypeId',
     [SOURCE_TYPES.ICON]: 'icon',
-    [SOURCE_TYPES.SRC]: 'src'
+    [SOURCE_TYPES.SRC]: 'src',
+    [SOURCE_TYPES.INSTAGRAM]: 'instagramId',
+    [SOURCE_TYPES.VKONTAKTE]: 'vkontakteId'
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,8 +12,7 @@ export const SOURCE_TYPES = {
     VKONTAKTE: 'VKONTAKTE'
 };
 
-// maps the unified source attribute to the appropriate value that is used by each source
-// instance to fetch is data
+// maps the source attribute required by a source to fetch its data
 export const SOURCE_TYPE_SRC_MAPPING = {
     [SOURCE_TYPES.FACEBOOK]: 'facebookId',
     [SOURCE_TYPES.GITHUB]: 'githubHandle',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,23 @@
+
+export const SOURCE_TYPES = {
+    FACEBOOK: 'FACEBOOK',
+    GITHUB: 'GITHUB',
+    GOOGLE: 'GOOGLE',
+    GRAVATAR: 'GRAVATAR',
+    ICON: 'ICON',
+    SKYPE: 'SKYPE',
+    TWITTER: 'TWITTER',
+    SRC: 'SRC'
+};
+
+// maps the unified source attribute to the appropriate value that is used by each source
+// instance to fetch is data
+export const SOURCE_TYPE_SRC_MAPPING = {
+    [SOURCE_TYPES.FACEBOOK]: 'facebookId',
+    [SOURCE_TYPES.GITHUB]: 'githubHandle',
+    [SOURCE_TYPES.GOOGLE]: 'googleId',
+    [SOURCE_TYPES.GRAVATAR]: 'email',
+    [SOURCE_TYPES.SKYPE]: 'skypeId',
+    [SOURCE_TYPES.ICON]: 'icon',
+    [SOURCE_TYPES.SRC]: 'src'
+};

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,8 @@ class Avatar extends PureComponent {
         unstyled: PropTypes.bool,
         cache: PropTypes.object,
         onClick: PropTypes.func,
-        uri: PropTypes.string // protocol gh://patricksimonian?
+        uri: PropTypes.string,
+        allowUriProps: PropTypes.bool // allows the query string to map to props
 
     }
 
@@ -99,7 +100,8 @@ class Avatar extends PureComponent {
         textSizeRatio: 3,
         textMarginRatio: .15,
         unstyled: false,
-        uri: ''
+        uri: '',
+        allowUriProps: true
     }
 
     constructor(props) {
@@ -129,10 +131,12 @@ class Avatar extends PureComponent {
 
                     props = {
                         ...this.props,
-                        ...normalizedAvatarSourceMapping,
-                        ...otherProps
+                        ...normalizedAvatarSourceMapping
                     };
 
+                    if(this.props.allowUriProps) {
+                        props = {...props, ...otherProps};
+                    }
                 }
             } catch(e) {
                 // this failed for one of many reasons, incorrect data types

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,6 @@ function matchSource(Source, props, cb) {
 
     if(!instance.isCompatible(props))
         return cb();
-
     instance.get((state) => {
         const failedBefore = state &&
             state.hasOwnProperty('src') &&

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ class Avatar extends PureComponent {
             try {
                 const {source, src, otherProps} = parseURI(this.props.uri);
                 const normalizedSource = source.toUpperCase();
-                // does the normalized objects source type actually exist as apart of the enum?
+                // does the normalized source type actually exist as apart of the SOURCE TYPES enum?
                 if(Object.prototype.hasOwnProperty.call(SOURCE_TYPES, normalizedSource)) {
                     // returns the required prop that is needed by the matcher for the given source.
                     const normalizedAvatarSourceMapping = {
@@ -138,8 +138,7 @@ class Avatar extends PureComponent {
                     }
                 }
             } catch(e) {
-                // this failed for one of many reasons, incorrect data types
-                // failure to parse uri
+                // this failed most likely because uri was invalid or bad datatype
                 warning(true, 'Failed to parse uri');
             }
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 'use strict';
+import Parser from 'uri-parser';
 
 export
 function fetch(url, successCb, errorCb) {
@@ -112,3 +113,18 @@ function defaultInitials(name, { maxInitials }) {
         .slice(0, maxInitials)
         .join('');
 }
+
+
+/**
+ * takes in a uri and maps it to a object
+ * that mimics a source avatar
+ * @param {String} uri
+ */
+export const parseURI = uri => {
+    const { protocol, host, queryKey } = Parser.parse(uri);
+    return {
+        source: protocol,
+        src: host,
+        otherProps: queryKey || {}
+    };
+};


### PR DESCRIPTION
## URI Strings?
Mentioned in #152 

I feel like the ability to match up a source dynamically via a string would be great. The URI scheme works really well for this I find. 

Here is the API. The URI follows this scheme...

__`<SOURCE TYPE>://<source value/handle/id>?<props to pass to component dynamically>`__

The valid source types are:
- github
- facebook
- twitter
- skype
- instagram
... etc, 

You'd create a uri like: `github://patricksimonian?size=100`

## Query Params
The query params can be appended onto the string to apply props dyanmically to the `Avatar` component. I added a prop called `allowUriProps` (defaults to `true`) which can enable/disable this behaviour.

## Usage

```js
<Avatar uri="github://patricksimonian" allowUriProps={false} />

// or dynamically
// lets assume what i get back is this as data [{ service: 'facebook', id: 123123}],
const avatars = await axios.get('path to avatars')
const uris = avatars.map(a => `${a.service}://${a.id}`);

const avatars = uris.map(uri => <Avatar key="blah" uri={uri} size="100"/>)
```