### PR TITLE
[text scaling] fix scaling issue on hidden avatars

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -112,3 +112,26 @@ function defaultInitials(name, { maxInitials }) {
         .slice(0, maxInitials)
         .join('');
 }
+
+/**
+ * Grouped timeouts reduce the amount of timeouts trigged
+ * by grouping multiple handlers into a single setTimeout call.
+ *
+ * This reduces accuracy of the timeout but will be less expensive
+ * when multiple avatar have been loaded into view.
+ */
+const timeoutGroups = {};
+
+export
+function setGroupedTimeout(fn, ttl) {
+    if (timeoutGroups[ttl]) {
+        timeoutGroups[ttl].push(fn);
+        return;
+    }
+
+    const callbacks = timeoutGroups[ttl] = [fn];
+    setTimeout(() => {
+        delete timeoutGroups[ttl];
+        callbacks.forEach(cb => cb());
+    }, ttl);
+}


### PR DESCRIPTION
If a parent was not visible due to some parent having a `display: none`,
the text scaling will cause the font-size of the actual text value to
become `0px` and thus not be visible.

Resolves https://github.com/Sitebase/react-avatar/issues/159