### PR TITLE
 React 18 - add children to ConfigProvider interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,7 @@ interface CreateAvatarOptions {
 }
 
 export interface ConfigProvider {
+    children?: React.ReactNode;
     /**
      * A list of color values as strings from which the getRandomColor picks one at random.
      */


### PR DESCRIPTION
this adds the children props to the ConfigProvider interface