### PR TITLE
React 18 add children to ConfigProvider

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,7 @@ interface CreateAvatarOptions {
 }
 
 export interface ConfigProvider {
+    children?: React.ReactNode;
     /**
      * A list of color values as strings from which the getRandomColor picks one at random.
      */


### PR DESCRIPTION
React 18 [removed](https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71809927#71809927) default children props.
This adds children props to adjust ConfigProvider typings for the library to work with react 18